### PR TITLE
Fixed bloc and navigator bug

### DIFF
--- a/lib/bloc/discussion/discussion_bloc.dart
+++ b/lib/bloc/discussion/discussion_bloc.dart
@@ -346,7 +346,9 @@ class DiscussionBloc extends Bloc<DiscussionEvent, DiscussionState> {
         final discussion = await this.discussionRepository.createDiscussion(
             title: event.title, anonymityType: event.anonymityType);
         yield DiscussionLoadedState(
-            discussion: discussion, lastUpdate: DateTime.now());
+            discussion: discussion,
+            lastUpdate: DateTime.now(),
+            onboardingConciergeStep: getConciergeStep(discussion));
       } catch (err) {
         // TODO: We should probably say that we failed somewhere.
         yield originalState;

--- a/lib/screens/home_page/chats/chats_screen.dart
+++ b/lib/screens/home_page/chats/chats_screen.dart
@@ -38,21 +38,6 @@ class _ChatsScreenState extends State<ChatsScreen> with RouteAware {
 
     this._refreshController = RefreshController(initialRefresh: false);
     this._chatListKey = GlobalKey();
-    _loadLastRoute();
-  }
-
-  void _loadLastRoute() async {
-    var routeName = await chathamRouteObserverSingleton.retrieveLastRouteName();
-    var routeArgs =
-        await chathamRouteObserverSingleton.retriveLastRouteArguments();
-    if (routeName != null &&
-        routeName.startsWith('/Discussion') &&
-        routeArgs != null) {
-      SchedulerBinding.instance.addPostFrameCallback((_) async {
-        await Navigator.of(context).pushNamed(routeName, arguments: routeArgs);
-        chathamRouteObserverSingleton.hasLoadedApp = true;
-      });
-    }
   }
 
   @override

--- a/lib/screens/intro/intro_screen.dart
+++ b/lib/screens/intro/intro_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:delphis_app/bloc/auth/auth_bloc.dart';
 import 'package:delphis_app/bloc/gql_client/gql_client_bloc.dart';
 import 'package:delphis_app/tracking/constants.dart';
+import 'package:delphis_app/util/route_observer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_segment/flutter_segment.dart';
@@ -14,8 +15,34 @@ class IntroScreen extends StatelessWidget {
       GqlClientState clientState, AuthState authState) async {
     if (clientState is GqlClientConnectedState) {
       if (authState is InitializedAuthState && authState.isAuthed) {
-        Navigator.pushNamedAndRemoveUntil(
-            context, '/Home', (Route<dynamic> route) => false);
+        var loadedHome = false;
+        try {
+          var lastRoute = await chathamRouteObserverSingleton.retrieveLastRouteName();
+          var lastArgs = await chathamRouteObserverSingleton.retriveLastRouteArguments();
+          Navigator.pushNamedAndRemoveUntil(
+            context,
+            '/Home',
+            (Route<dynamic> route) => false
+          );
+          loadedHome = true;
+          Navigator.pushNamed(
+            context,
+            lastRoute,
+            arguments: lastArgs
+          );
+        }
+        catch (error) {
+          /* Probably something is broken in the local storage,
+             or simply there is no screen history saved.
+             In this case we just load the default home page. */
+          if(!loadedHome) {
+            Navigator.pushNamedAndRemoveUntil(
+              context,
+              '/Home',
+              (Route<dynamic> route) => false
+            );
+          }
+        }
         return true;
       } else if (authState is InitializedAuthState) {
         Navigator.pushNamedAndRemoveUntil(

--- a/lib/util/route_observer.dart
+++ b/lib/util/route_observer.dart
@@ -1,4 +1,5 @@
 import 'package:delphis_app/screens/discussion/screen_args/discussion.dart';
+import 'package:delphis_app/screens/discussion/screen_args/discussion_naming.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -34,6 +35,11 @@ class _ChathamRouteObserver extends RouteObserver {
               .toJsonString();
           argsType = 'DiscussionArguments';
           break;
+        case DiscussionNamingArguments:
+          encodedArgs = (lastRoute.settings.arguments as DiscussionNamingArguments)
+              .toJsonString();
+          argsType = 'DiscussionNamingArguments';
+          break;
         default:
           break;
       }
@@ -56,7 +62,8 @@ class _ChathamRouteObserver extends RouteObserver {
     switch (type) {
       case 'DiscussionArguments':
         return DiscussionArguments.fromJsonString(args);
-        break;
+      case 'DiscussionNamingArguments':
+        return DiscussionNamingArguments.fromJsonString(args);
       default:
         break;
     }


### PR DESCRIPTION
This fixes the problem related to #67. The last screen is now persisted and relaunched when the app is reopened. Additionally, this fixes a bug related to BLoC and navigation that made the HomeScreen rebuild when creating a new discussion and eventually interfere with its navigation.