### PR TITLE
Ui updates

### DIFF
--- a/lib/data/repository/discussion.dart
+++ b/lib/data/repository/discussion.dart
@@ -515,4 +515,11 @@ class Discussion extends Equatable implements Entity {
     }
     return participant;
   }
+
+  bool isMeDiscussionModerator() {
+    return this.meAvailableParticipants
+        ?.map((e) => e?.userProfile?.id)
+        ?.contains(this.moderator?.userProfile?.id) ?? false;
+  }
+
 }

--- a/lib/screens/discussion/discussion.dart
+++ b/lib/screens/discussion/discussion.dart
@@ -1,12 +1,14 @@
 import 'dart:io';
 import 'package:delphis_app/bloc/auth/auth_bloc.dart';
 import 'package:delphis_app/bloc/discussion/discussion_bloc.dart';
+import 'package:delphis_app/bloc/participant/participant_bloc.dart';
 import 'package:delphis_app/bloc/superpowers/superpowers_bloc.dart';
 import 'package:delphis_app/bloc/notification/notification_bloc.dart';
 import 'package:delphis_app/data/repository/concierge_content.dart';
 import 'package:delphis_app/data/repository/discussion.dart';
 import 'package:delphis_app/data/repository/media.dart';
 import 'package:delphis_app/data/repository/post.dart';
+import 'package:delphis_app/design/colors.dart';
 import 'package:delphis_app/screens/discussion/header_options_button.dart';
 import 'package:delphis_app/screens/discussion/media/media_preview.dart';
 import 'package:delphis_app/screens/discussion/screen_args/superpowers_arguments.dart';
@@ -163,6 +165,20 @@ class DelphisDiscussionState extends State<DelphisDiscussion> {
               .add(SubscribeToDiscussionEvent(this.widget.discussionID, true));
         }
         final discussionObj = state.getDiscussion();
+        
+        /* In some old discussions the moderator was able to go in incognito mode.
+           if this happens, then we re-force to non-incognito mode. By using BLoCs,
+           the UI is rebuilt automatically. */
+        if((discussionObj?.meParticipant?.isAnonymous ?? false) && (discussionObj?.isMeDiscussionModerator() ?? false)) {
+          BlocProvider.of<ParticipantBloc>(context).add(ParticipantEventUpdateParticipant(
+            participantID: discussionObj.meParticipant.id,
+            isAnonymous: false,
+            gradientName: gradientNameFromString(discussionObj.meParticipant.gradientColor),
+            flair: discussionObj.meParticipant.flair,
+            isUnsetFlairID:  discussionObj.meParticipant.flair == null,
+          ));
+        }
+
         final expandedConversationView = Expanded(
           child: DiscussionContent(
             key: Key('${this._key}-content'),

--- a/lib/screens/discussion/discussion.dart
+++ b/lib/screens/discussion/discussion.dart
@@ -180,7 +180,7 @@ class DelphisDiscussionState extends State<DelphisDiscussion> {
                 // of dependencies involved.
                 BlocProvider.of<DiscussionBloc>(context).add(
                     DiscussionQueryEvent(
-                        discussionID: discussionObj.id, nonce: DateTime.now()));
+                        discussionID: this.widget.discussionID, nonce: DateTime.now()));
               }
               setState(() {
                 this._isShowJoinFlow = false;
@@ -238,7 +238,7 @@ class DelphisDiscussionState extends State<DelphisDiscussion> {
             ),
             expandedConversationView,
             DelphisInputContainer(
-              hasJoined: discussionObj.meParticipant != null,
+              hasJoined: discussionObj?.meParticipant?.hasJoined ?? false,
               isJoinable: true,
               discussion: discussionObj,
               participant: discussionObj.meParticipant,

--- a/lib/screens/discussion/discussion_post.dart
+++ b/lib/screens/discussion/discussion_post.dart
@@ -240,7 +240,7 @@ class _DiscussionPostState extends State<DiscussionPost> with TickerProviderStat
   }
 
   bool isMeDiscussionModerator() {
-    return this.widget.discussion?.moderator?.userProfile?.id == this.widget.discussion?.meParticipant?.userProfile?.id;
+    return this.widget.discussion?.isMeDiscussionModerator() ?? false;
   }
 
   bool isMePostAuthor() {

--- a/lib/screens/discussion/overlay/participant_gradient_selector.dart
+++ b/lib/screens/discussion/overlay/participant_gradient_selector.dart
@@ -27,6 +27,7 @@ class ParticipantGradientSelector extends StatefulWidget {
 class _ParticipantGradientSelectorState
     extends State<ParticipantGradientSelector> {
   GradientName _pickedGradient;
+  bool firstSelection;
 
   @override
   void initState() {
@@ -34,6 +35,7 @@ class _ParticipantGradientSelectorState
 
     // TODO: set this from the participant field.
     this._pickedGradient = this.widget.selectedGradient;
+    this.firstSelection = true;
   }
 
   @override
@@ -117,6 +119,7 @@ class _ParticipantGradientSelectorState
                 child: InkWell(
                   onTap: () {
                     this.setState(() {
+                      this.firstSelection = false;
                       this._pickedGradient = gradientName;
                     });
                   },
@@ -153,12 +156,13 @@ class _ParticipantGradientSelectorState
                         vertical: SpacingValues.medium),
                     shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(25.0)),
-                    color: Color.fromRGBO(247, 247, 255, 0.2),
+                    color: this.firstSelection ? Color.fromRGBO(247, 247, 255, 0.2) : Color.fromRGBO(247, 247, 255, 1.0),
                     child: Text(Intl.message('Save color'),
-                        style: TextThemes.goIncognitoButton),
-                    onPressed: () {
+                        style: this.firstSelection ? TextThemes.goIncognitoButton : TextThemes.joinButtonTextChatTab),
+                    onPressed: this.firstSelection ? null : () {
                       this.widget.onSave(this._pickedGradient);
                     },
+                    
                   ),
                 ],
               ),

--- a/lib/screens/discussion/overlay/participant_settings.dart
+++ b/lib/screens/discussion/overlay/participant_settings.dart
@@ -328,7 +328,7 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
     }
     return Text(
       this.widget.settingsFlow == SettingsFlow.PARTICIPANT_SETTINGS_IN_CHAT
-        ? Intl.message('Go Incognito?')
+        ? (this.widget.meParticipant.isAnonymous ? Intl.message("Go Public?") : Intl.message('Go Incognito?'))
         : Intl.message('How would you like to join?'),
       style: TextThemes.goIncognitoHeader,
       textAlign: TextAlign.center,

--- a/lib/screens/discussion/overlay/participant_settings.dart
+++ b/lib/screens/discussion/overlay/participant_settings.dart
@@ -129,7 +129,7 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
                 padding: EdgeInsets.symmetric(vertical: SpacingValues.small),
                 shrinkWrap: true,
                 children: [
-                  this.widget.meParticipant.isAnonymous
+                  this.widget.meParticipant.isAnonymous || this.widget.settingsFlow == SettingsFlow.JOIN_CHAT
                     ? ParticipantAnonymitySettingOption(
                         height: 40.0,
                         user: this.widget.me,
@@ -150,8 +150,9 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
                         },
                         showEditButton: this.widget.me.flairs != null &&
                             this.widget.me.flairs.length > 0,
-                      )
-                    : ParticipantAnonymitySettingOption(
+                      ) : Container(),
+                    !this.widget.meParticipant.isAnonymous || this.widget.settingsFlow == SettingsFlow.JOIN_CHAT
+                    ? ParticipantAnonymitySettingOption(
                         height: 40.0,
                         user: this.widget.me,
                         anonymousGradient: this._selectedGradient,
@@ -171,7 +172,7 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
                         },
                         showEditButton: this.widget.me.flairs != null &&
                             this.widget.me.flairs.length > 0
-                      ),
+                      ) : Container(),
                 ]),
             Container(height: 1.0, color: Color.fromRGBO(110, 111, 121, 0.6)),
             Padding(

--- a/lib/screens/discussion/overlay/participant_settings.dart
+++ b/lib/screens/discussion/overlay/participant_settings.dart
@@ -166,9 +166,12 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
                         },
                         onEdit: () {
                           this.setState(() {
-                            this._settingsState = _SettingsState.GRADIENT_SELECT;
+                            this._settingsState = _SettingsState.FLAIR_SELECT;
                           });
-                        }),
+                        },
+                        showEditButton: this.widget.me.flairs != null &&
+                            this.widget.me.flairs.length > 0
+                      ),
                 ]),
             Container(height: 1.0, color: Color.fromRGBO(110, 111, 121, 0.6)),
             Padding(

--- a/lib/screens/discussion/overlay/participant_settings.dart
+++ b/lib/screens/discussion/overlay/participant_settings.dart
@@ -206,7 +206,7 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
               ),
             ],
             border:
-                Border.all(color: Color.fromRGBO(34, 35, 40, 1.0), width: 1.5),
+                Border.all(color: Color.fromRGBO(22, 25, 28, 1.0), width: 1.5),
             borderRadius: BorderRadius.only(
                 topLeft: Radius.circular(36.0),
                 topRight: Radius.circular(36.0)),

--- a/lib/screens/discussion/overlay/superpowers_popup.dart
+++ b/lib/screens/discussion/overlay/superpowers_popup.dart
@@ -225,7 +225,7 @@ class SuperpowersPopup extends StatelessWidget {
   }
 
   bool isMeDiscussionModerator() {
-    return this.arguments.discussion?.moderator?.userProfile?.id == this.arguments.discussion?.meParticipant?.userProfile?.id;
+    return this.arguments?.discussion?.isMeDiscussionModerator() ?? false;
   }
 
   bool isMePostAuthor() {

--- a/lib/screens/discussion/post_title.dart
+++ b/lib/screens/discussion/post_title.dart
@@ -1,6 +1,7 @@
 import 'package:delphis_app/data/repository/flair.dart';
 import 'package:delphis_app/data/repository/moderator.dart';
 import 'package:delphis_app/data/repository/participant.dart';
+import 'package:delphis_app/design/colors.dart';
 import 'package:delphis_app/design/sizes.dart';
 import 'package:delphis_app/design/text_theme.dart';
 import 'package:delphis_app/util/display_names.dart';
@@ -29,7 +30,8 @@ class PostTitle extends StatelessWidget {
         this.key == null ? null : Key('${this.key.toString}-displayName');
 
     var name = Text(DisplayNames.formatParticipant(moderator, participant),
-        style: TextThemes.discussionPostAuthorAnon,
+        style: TextThemes.discussionPostAuthorAnon.copyWith(color: ChathamColors.gradients[gradientNameFromString(
+                this.participant?.gradientColor)].colors[1]),
         key: textKey);
     if (participant.participantID == 0) {
       // This is the moderator

--- a/lib/screens/home_page/chats/chats_list.dart
+++ b/lib/screens/home_page/chats/chats_list.dart
@@ -100,12 +100,13 @@ class ChatsList extends StatelessWidget {
                 if(index == 0)
                   return errorWidget;
                 index--;
-                final discussionElem = state.discussionList[index];
+                var discussionElem = state.discussionList[index];
                 return BlocBuilder<DiscussionBloc, DiscussionState>(
                   builder: (context, discussionState) {
                     if(discussionState is DiscussionLoadedState && discussionState.getDiscussion() != null) {
                       if(discussionState.getDiscussion().id == discussionElem.id) {
-                        state.discussionList.replaceRange(index, index + 1, [discussionState.getDiscussion()]);
+                        state.discussionList[index] = discussionState.getDiscussion();
+                        discussionElem = state.discussionList[index];
                       }
                     }
                     return SingleChat(

--- a/lib/screens/home_page/chats/chats_list.dart
+++ b/lib/screens/home_page/chats/chats_list.dart
@@ -1,3 +1,4 @@
+import 'package:delphis_app/bloc/discussion/discussion_bloc.dart';
 import 'package:delphis_app/bloc/discussion_list/discussion_list_bloc.dart';
 import 'package:delphis_app/design/sizes.dart';
 import 'package:delphis_app/screens/home_page/chats/single_chat.dart';
@@ -100,16 +101,25 @@ class ChatsList extends StatelessWidget {
                   return errorWidget;
                 index--;
                 final discussionElem = state.discussionList[index];
-                return SingleChat(
-                  discussion: discussionElem,
-                  onJoinPressed: () {
-                    this.onJoinDiscussionPressed(discussionElem);
-                  },
-                  onDeletePressed: () {
-                    this.onDeleteDiscussionInvitePressed(discussionElem);
-                  },
-                  onPressed: () {
-                    this.onDiscussionPressed(discussionElem);
+                return BlocBuilder<DiscussionBloc, DiscussionState>(
+                  builder: (context, discussionState) {
+                    if(discussionState is DiscussionLoadedState && discussionState.getDiscussion() != null) {
+                      if(discussionState.getDiscussion().id == discussionElem.id) {
+                        state.discussionList.replaceRange(index, index + 1, [discussionState.getDiscussion()]);
+                      }
+                    }
+                    return SingleChat(
+                      discussion: discussionElem,
+                      onJoinPressed: () {
+                        this.onJoinDiscussionPressed(discussionElem);
+                      },
+                      onDeletePressed: () {
+                        this.onDeleteDiscussionInvitePressed(discussionElem);
+                      },
+                      onPressed: () {
+                        this.onDiscussionPressed(discussionElem);
+                      },
+                    );
                   },
                 );
               },

--- a/lib/screens/home_page/chats/single_chat_joined.dart
+++ b/lib/screens/home_page/chats/single_chat_joined.dart
@@ -77,7 +77,7 @@ class SingleChatJoined extends StatelessWidget {
               ),
               SizedBox(width: SpacingValues.small),
               ModeratorProfileImage(
-                starTopLeftMargin: 21.5,
+                starTopLeftMargin: 21,
                 starSize: 12,
                 diameter: 32.0,
                 profileImageURL:

--- a/lib/screens/home_page/chats/single_chat_unjoined.dart
+++ b/lib/screens/home_page/chats/single_chat_unjoined.dart
@@ -51,7 +51,7 @@ class SingleChatUnjoined extends StatelessWidget {
                             mainAxisAlignment: MainAxisAlignment.start,
                             children: [
                               ModeratorProfileImage(
-                                  starTopLeftMargin: 14.9,
+                                  starTopLeftMargin: 12.5,
                                   starSize: 12,
                                   diameter: 22.0,
                                   profileImageURL: this


### PR DESCRIPTION
This targets #18, #21, #29, #66. Overall, the following has been changed:
- The name of anonymous participants is now colored in the chat accordingly to their gradient.
- Color picker cannot be opened anymore after having joined the chat. When users join the chat, they can select their gradient.
- The gradient picker "update" button gets activated (even its UI) only when at least a gradient is selected.
- Flairs can be changed even while in incognito.
- Moderators can't go in incognito. If for some buggy reason a mod is already in incognito, it gets changed automatically.
- Participant settings popup border is now brighter (color  #222328).
- Fixed a BLoC-related bug that opened the wrong discussion when a user first joins one.