### PR TITLE
Discussion subscription events

### DIFF
--- a/lib/bloc/discussion/discussion_event.dart
+++ b/lib/bloc/discussion/discussion_event.dart
@@ -93,6 +93,28 @@ class DiscussionPostAddedEvent extends DiscussionEvent {
   }) : super();
 }
 
+class DiscussionPostDeletedEvent extends DiscussionEvent {
+  final Post post;
+
+  @override
+  List<Object> get props => [this.post];
+
+  DiscussionPostDeletedEvent({
+    @required this.post,
+  }) : super();
+}
+
+class DiscussionParticipantBannedEvent extends DiscussionEvent {
+  final Participant participant;
+
+  @override
+  List<Object> get props => [this.participant];
+
+  DiscussionParticipantBannedEvent({
+    @required this.participant,
+  }) : super();
+}
+
 class SubscribeToDiscussionEvent extends DiscussionEvent {
   final String discussionID;
   final bool isSubscribed;

--- a/lib/bloc/discussion/discussion_state.dart
+++ b/lib/bloc/discussion/discussion_state.dart
@@ -36,7 +36,7 @@ class DiscussionErrorState extends DiscussionState {
 class DiscussionLoadedState extends DiscussionState {
   final Discussion discussion;
   final DateTime lastUpdate;
-  final Stream<Post> discussionPostStream;
+  final Stream<DiscussionSubscriptionEvent> discussionPostStream;
   final Map<GlobalKey, LocalPost> localPosts;
 
   final bool isLoading;
@@ -58,7 +58,7 @@ class DiscussionLoadedState extends DiscussionState {
   }
 
   DiscussionLoadedState update({
-    Stream<Post> stream,
+    Stream<DiscussionSubscriptionEvent> stream,
     Discussion discussion,
     Map<GlobalKey, LocalPost> localPosts,
     bool isLoading,

--- a/lib/data/provider/queries.dart
+++ b/lib/data/provider/queries.dart
@@ -16,6 +16,7 @@ const ParticipantInfoFragment = """
     id
     participantID
     isAnonymous
+    isBanned
     gradientColor
     flair {
       id

--- a/lib/data/provider/subscriptions.dart
+++ b/lib/data/provider/subscriptions.dart
@@ -1,5 +1,5 @@
 import 'package:delphis_app/data/provider/queries.dart';
-import 'package:delphis_app/data/repository/post.dart';
+import 'package:delphis_app/data/repository/discussion_subscription.dart';
 
 abstract class GQLSubscription<T> {
   T parseResult(dynamic data);
@@ -8,24 +8,33 @@ abstract class GQLSubscription<T> {
   const GQLSubscription();
 }
 
-class PostAddedSubscription extends GQLSubscription<Post> {
+class DiscussionEventSubscription extends GQLSubscription<DiscussionSubscriptionEvent> {
   final String discussionID;
   final String _subscription = """
-    subscription postAdded(\$discussionID: String!) {
-      postAdded(discussionID: \$discussionID) {
-        ...PostWithParticipantInfoFragment
+    subscription onDiscussionEvent(\$discussionID: String!) {
+      onDiscussionEvent(discussionID: \$discussionID) {
+        eventType
+        entity {
+          id
+          ... on Post {
+            ...PostWithParticipantInfoFragment
+          }
+          ... on Participant {
+            ...ParticipantInfoFragment
+          }
+        }
       }
     }
     $PostWithParticipantInfoFragment
   """;
 
-  const PostAddedSubscription(this.discussionID) : super();
+  const DiscussionEventSubscription(this.discussionID) : super();
 
   String subscription() {
     return this._subscription;
   }
 
-  Post parseResult(dynamic data) {
-    return Post.fromJson(data["postAdded"]);
+  DiscussionSubscriptionEvent parseResult(dynamic data) {
+    return DiscussionSubscriptionEvent.fromJson(data["onDiscussionEvent"]);
   }
 }

--- a/lib/data/repository/discussion_subscription.dart
+++ b/lib/data/repository/discussion_subscription.dart
@@ -1,0 +1,81 @@
+import 'package:delphis_app/data/repository/participant.dart';
+import 'package:delphis_app/data/repository/post.dart';
+import 'package:flutter/material.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:equatable/equatable.dart';
+
+part 'discussion_subscription.g.dart';
+
+@JsonSerializable()
+class DiscussionSubscriptionEvent extends Equatable {
+  final DiscussionSubscriptionEventType eventType;
+
+  const DiscussionSubscriptionEvent({
+    this.eventType
+  });
+  
+  factory DiscussionSubscriptionEvent.fromJson(Map<String, dynamic> json) {
+    var obj = _$DiscussionSubscriptionEventFromJson(json);
+    switch(obj.eventType) {
+      case DiscussionSubscriptionEventType.POST_ADDED:
+        return DiscussionSubscriptionPostAdded(post: Post.fromJson(json["entity"]));
+      case DiscussionSubscriptionEventType.POST_DELETED:
+        return DiscussionSubscriptionPostDeleted(post: Post.fromJson(json["entity"]));
+      case DiscussionSubscriptionEventType.PARTICIPANT_BANNED:
+        return DiscussionSubscriptionParticipantBanned(participant: Participant.fromJson(json["entity"]));
+    }
+    throw "Unknown DiscussionSubscriptionEvent type";
+  }
+
+  @override
+  List<Object> get props => [eventType];
+
+}
+
+enum DiscussionSubscriptionEventType {
+    POST_ADDED,
+    POST_DELETED,
+    PARTICIPANT_BANNED
+}
+
+class DiscussionSubscriptionPostAdded extends DiscussionSubscriptionEvent{
+  final Post post;
+
+  get eventType => DiscussionSubscriptionEventType.POST_ADDED;
+  
+  DiscussionSubscriptionPostAdded({
+    @required this.post
+  });
+
+  @override
+  List<Object> get props => [post];
+  
+}
+
+class DiscussionSubscriptionPostDeleted extends DiscussionSubscriptionEvent{
+  final Post post;
+
+  get eventType => DiscussionSubscriptionEventType.POST_DELETED;
+  
+  DiscussionSubscriptionPostDeleted({
+    @required this.post
+  });
+  
+  @override
+  List<Object> get props => [post];
+
+}
+
+class DiscussionSubscriptionParticipantBanned extends DiscussionSubscriptionEvent{
+  final Participant participant;
+
+  get eventType => DiscussionSubscriptionEventType.PARTICIPANT_BANNED;
+  
+  DiscussionSubscriptionParticipantBanned({
+    @required this.participant
+  });
+
+  @override
+  List<Object> get props => [participant];
+  
+}

--- a/lib/data/repository/discussion_subscription.g.dart
+++ b/lib/data/repository/discussion_subscription.g.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'discussion_subscription.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+DiscussionSubscriptionEvent _$DiscussionSubscriptionEventFromJson(
+    Map<String, dynamic> json) {
+  return DiscussionSubscriptionEvent(
+    eventType: _$enumDecodeNullable(
+        _$DiscussionSubscriptionEventTypeEnumMap, json['eventType']),
+  );
+}
+
+Map<String, dynamic> _$DiscussionSubscriptionEventToJson(
+        DiscussionSubscriptionEvent instance) =>
+    <String, dynamic>{
+      'eventType': _$DiscussionSubscriptionEventTypeEnumMap[instance.eventType],
+    };
+
+T _$enumDecode<T>(
+  Map<T, dynamic> enumValues,
+  dynamic source, {
+  T unknownValue,
+}) {
+  if (source == null) {
+    throw ArgumentError('A value must be provided. Supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+
+  final value = enumValues.entries
+      .singleWhere((e) => e.value == source, orElse: () => null)
+      ?.key;
+
+  if (value == null && unknownValue == null) {
+    throw ArgumentError('`$source` is not one of the supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return value ?? unknownValue;
+}
+
+T _$enumDecodeNullable<T>(
+  Map<T, dynamic> enumValues,
+  dynamic source, {
+  T unknownValue,
+}) {
+  if (source == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source, unknownValue: unknownValue);
+}
+
+const _$DiscussionSubscriptionEventTypeEnumMap = {
+  DiscussionSubscriptionEventType.POST_ADDED: 'POST_ADDED',
+  DiscussionSubscriptionEventType.POST_DELETED: 'POST_DELETED',
+  DiscussionSubscriptionEventType.PARTICIPANT_BANNED: 'PARTICIPANT_BANNED',
+};

--- a/lib/data/repository/participant.dart
+++ b/lib/data/repository/participant.dart
@@ -241,6 +241,7 @@ class Participant extends Equatable implements Entity {
   final Viewer viewer;
   final List<Post> posts;
   final bool isAnonymous;
+  final bool isBanned;
   final String gradientColor;
   final Flair flair;
   final bool hasJoined;
@@ -262,6 +263,7 @@ class Participant extends Equatable implements Entity {
     this.hasJoined,
     this.userProfile,
     this.inviter,
+    this.isBanned
   });
 
   factory Participant.fromJson(Map<String, dynamic> json) =>

--- a/lib/data/repository/participant.g.dart
+++ b/lib/data/repository/participant.g.dart
@@ -32,6 +32,7 @@ Participant _$ParticipantFromJson(Map<String, dynamic> json) {
     inviter: json['inviter'] == null
         ? null
         : Participant.fromJson(json['inviter'] as Map<String, dynamic>),
+    isBanned: json['isBanned'] as bool,
   );
 }
 
@@ -43,6 +44,7 @@ Map<String, dynamic> _$ParticipantToJson(Participant instance) =>
       'viewer': instance.viewer,
       'posts': instance.posts,
       'isAnonymous': instance.isAnonymous,
+      'isBanned': instance.isBanned,
       'gradientColor': instance.gradientColor,
       'flair': instance.flair,
       'hasJoined': instance.hasJoined,

--- a/lib/screens/discussion/discussion_header.dart
+++ b/lib/screens/discussion/discussion_header.dart
@@ -103,6 +103,7 @@ class _DiscussionHeaderState extends State<DiscussionHeader>
             Row(
               children: <Widget>[
                 ParticipantImages(
+                  moderator : this.widget.discussion.moderator,
                   height: HeightValues.appBarItemsHeight,
                   participants: this.widget.discussion.participants,
                 ),

--- a/lib/screens/home_page/chats/single_chat_joined.dart
+++ b/lib/screens/home_page/chats/single_chat_joined.dart
@@ -71,6 +71,7 @@ class SingleChatJoined extends StatelessWidget {
                 ),
               ),
               ParticipantImages(
+                moderator: this.discussion.moderator,
                 height: 28.0,
                 maxNonAnonToShow: 4,
                 participants: this.discussion.participants,

--- a/lib/widgets/discussion_header/participant_images.dart
+++ b/lib/widgets/discussion_header/participant_images.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:delphis_app/data/repository/moderator.dart';
 import 'package:delphis_app/data/repository/participant.dart';
 import 'package:delphis_app/widgets/profile_image/profile_image.dart';
 import 'package:flutter/material.dart';
@@ -10,11 +11,13 @@ class ParticipantImages extends StatelessWidget {
 
   final double height;
   final List<Participant> participants;
+  final Moderator moderator;
   final int maxNonAnonToShow;
 
   const ParticipantImages({
     @required this.height,
     @required participants,
+    @required this.moderator,
     this.maxNonAnonToShow = 5,
   })  : this.participants =
             participants == null ? emptyParticipantList : participants,
@@ -23,6 +26,12 @@ class ParticipantImages extends StatelessWidget {
   List<Widget> generateProfileImages(
       List<Participant> anon, List<Participant> nonAnon) {
     final List<Widget> response = List<Widget>();
+    
+    nonAnon = nonAnon
+      .where((p) => !p.isBanned && p.userProfile != null)
+      .where((p) => (p.userProfile.id != this.moderator?.userProfile?.id) ?? false)
+      .toList();
+
     final numWidgetsToCreate = min(nonAnon.length, this.maxNonAnonToShow);
     for (int i = 0; i < numWidgetsToCreate; i++) {
       response.add(ProfileImage(


### PR DESCRIPTION
This is coupled with https://github.com/delphis-inc/delphisbe/pull/73.
- Implements the support for the new discussion events subscription system.
- Solves some null-ptr problems related to participant banning.
- Removes the moderator from being shown twice on the participants profile images in discussion headers (this has been reported as an issue).