### PR TITLE
Integrate new filtered query

### DIFF
--- a/lib/bloc/discussion_list/discussion_list_bloc.dart
+++ b/lib/bloc/discussion_list/discussion_list_bloc.dart
@@ -27,16 +27,7 @@ class DiscussionListBloc
     if(event is DiscussionListFetchEvent && !(this.state is DiscussionListLoading)) {
       try {
         yield DiscussionListLoading(discussionList: prevList, timestamp: DateTime.now());
-        var newList;
-        if (meBloc.state is LoadedMeState) {
-          try {
-            newList = await this.repository.getMyDiscussionList();
-          } catch (err) {
-            newList = await this.repository.getDiscussionList();
-          }
-        } else {
-          newList = await this.repository.getDiscussionList();
-        }
+        var newList = await this.repository.getDiscussionList();
         yield DiscussionListLoaded(discussionList: newList, timestamp: DateTime.now());
       }
       catch (error) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -386,7 +386,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1"
+    version: "0.12.2"
   http_multi_server:
     dependency: transitive
     description:
@@ -853,7 +853,7 @@ packages:
       name: synchronized
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0+1"
+    version: "2.2.0+2"
   term_glyph:
     dependency: transitive
     description:


### PR DESCRIPTION
This is required to properly use the new backed user-customized `listDiscussions` query. Fetching discussions for the `me` user is now useless as they are already filtered for the logged in user. Also, that query doesn't respect the new discussion list ordering implemented on the backend.