### PR TITLE
Image fouc fix

### DIFF
--- a/lib/screens/discussion/discussion_content.dart
+++ b/lib/screens/discussion/discussion_content.dart
@@ -47,7 +47,7 @@ class DiscussionContent extends StatelessWidget {
 
   final VoidCallback onModeratorOverlayClose;
 
-  DiscussionContent({
+  const DiscussionContent({
     @required key,
     @required this.scrollController,
     @required this.discussion,

--- a/lib/screens/discussion/discussion_post.dart
+++ b/lib/screens/discussion/discussion_post.dart
@@ -238,7 +238,7 @@ class _DiscussionPostState extends State<DiscussionPost> with TickerProviderStat
     return Consumer<MediaChangeNotifier>(
       builder: (context, value, child) {
         if(value.hasData()) {
-          return MediaLoadedSnippet(
+          return LoadedMediaSnippetWidget(
             mediaContentType: value.mediaContentType,
             file: value.file,
             image: value.imageProvider,

--- a/lib/screens/discussion/discussion_post.dart
+++ b/lib/screens/discussion/discussion_post.dart
@@ -12,6 +12,7 @@ import 'package:delphis_app/data/repository/post_content_input.dart';
 import 'package:delphis_app/design/colors.dart';
 import 'package:delphis_app/design/sizes.dart';
 import 'package:delphis_app/screens/discussion/concierge_discussion_post_options.dart';
+import 'package:delphis_app/screens/discussion/media/media_loaded_snippet.dart';
 import 'package:delphis_app/screens/discussion/media/media_snippet.dart';
 import 'package:delphis_app/screens/discussion/screen_args/superpowers_arguments.dart';
 import 'package:delphis_app/widgets/animated_background_color/animated_background_color.dart';
@@ -23,7 +24,9 @@ import 'package:delphis_app/widgets/profile_image/profile_image_and_inviter.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 
+import 'media/media_change_notifier.dart';
 import 'post_title.dart';
 
 typedef ConciergePostOptionPressed(
@@ -232,10 +235,25 @@ class _DiscussionPostState extends State<DiscussionPost> with TickerProviderStat
       return Container();
     }
     
-    return MediaSnippetWidget(
-      key: UniqueKey(),
-      post: this.widget.post,
-      onTap: this.widget.onMediaTap
+    return Consumer<MediaChangeNotifier>(
+      builder: (context, value, child) {
+        if(value.hasData()) {
+          return MediaLoadedSnippet(
+            mediaContentType: value.mediaContentType,
+            file: value.file,
+            image: value.imageProvider,
+            onTap: () => this.widget.onMediaTap(value.file, value.mediaContentType)
+          );
+        }
+        
+        return MediaSnippetWidget(
+          post: this.widget.post,
+          onTap: this.widget.onMediaTap,
+          onMediaLoaded: (file, image, type) {
+            Provider.of<MediaChangeNotifier>(context, listen: false).setData(file, image, type);
+          }
+        );
+      },
     );
   }
 

--- a/lib/screens/discussion/discussion_post_list_view.dart
+++ b/lib/screens/discussion/discussion_post_list_view.dart
@@ -4,14 +4,15 @@ import 'dart:math';
 import 'package:delphis_app/bloc/discussion/discussion_bloc.dart';
 import 'package:delphis_app/data/repository/discussion.dart';
 import 'package:delphis_app/data/repository/media.dart';
-import 'package:delphis_app/data/repository/post.dart';
 import 'package:delphis_app/data/repository/post_content_input.dart';
+import 'package:delphis_app/screens/discussion/media/media_change_notifier.dart';
 import 'package:delphis_app/screens/discussion/screen_args/superpowers_arguments.dart';
 import 'package:delphis_app/widgets/discussion_icon/discussion_icon.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
 
 import 'discussion_announcement_post.dart';
@@ -33,7 +34,7 @@ class DiscussionPostListView extends StatelessWidget {
 
   final Function(SuperpowersArguments) onSuperpowersButtonPressed;
 
-  DiscussionPostListView({
+  const DiscussionPostListView({
     @required key,
     @required this.scrollController,
     @required this.discussion,
@@ -49,7 +50,6 @@ class DiscussionPostListView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final discussionBloc = BlocProvider.of<DiscussionBloc>(context);
-
     final numConciergePosts = (this.discussion.postsCache ?? []).where((post) {
       return post.postType == PostType.CONCIERGE;
     }).length;
@@ -172,6 +172,7 @@ class DiscussionPostListView extends StatelessWidget {
           reverse: true,
           itemBuilder: (context, index) {
             final post = DiscussionPost(
+              key: UniqueKey(),
               onConciergeOptionPressed: this.onConciergeOptionPressed,
               // I think this will break due to paging.
               conciergeIndex: max(
@@ -185,7 +186,10 @@ class DiscussionPostListView extends StatelessWidget {
               onModeratorButtonPressed: this.onSuperpowersButtonPressed,
             );
             if (true) {
-              return post;
+              return ChangeNotifierProvider(
+                create: (context) => MediaChangeNotifier(),
+                child: post
+              );
             } else {
               // TODO: This should be hooked up to announcement posts.
               return DiscussionAnnouncementPost(post: post);

--- a/lib/screens/discussion/media/media_change_notifier.dart
+++ b/lib/screens/discussion/media/media_change_notifier.dart
@@ -1,0 +1,22 @@
+
+import 'dart:io';
+
+import 'package:delphis_app/data/repository/media.dart';
+import 'package:flutter/material.dart';
+
+class MediaChangeNotifier extends ChangeNotifier {
+  ImageProvider imageProvider;
+  MediaContentType mediaContentType;
+  File file;
+
+  bool hasData() {
+    return file != null && imageProvider != null && mediaContentType != null;
+  }
+  void setData(File file, ImageProvider imageProvider, MediaContentType mediaContentType) {
+    this.file = file;
+    this.imageProvider = imageProvider;
+    this.mediaContentType = mediaContentType;
+    this.notifyListeners();
+  }
+
+}

--- a/lib/screens/discussion/media/media_loaded_snippet.dart
+++ b/lib/screens/discussion/media/media_loaded_snippet.dart
@@ -4,13 +4,13 @@ import 'package:delphis_app/data/repository/media.dart';
 import 'package:delphis_app/design/sizes.dart';
 import 'package:flutter/material.dart';
 
-class MediaLoadedSnippet extends StatelessWidget {
+class LoadedMediaSnippetWidget extends StatelessWidget {
   final File file;
   final ImageProvider image;
   final VoidCallback onTap;
   final MediaContentType mediaContentType;
 
-  const MediaLoadedSnippet({
+  const LoadedMediaSnippetWidget({
     Key key,
     @required this.file,
     @required this.image,

--- a/lib/screens/discussion/media/media_loaded_snippet.dart
+++ b/lib/screens/discussion/media/media_loaded_snippet.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'package:delphis_app/data/repository/media.dart';
+import 'package:delphis_app/design/sizes.dart';
+import 'package:flutter/material.dart';
+
+class MediaLoadedSnippet extends StatelessWidget {
+  final File file;
+  final ImageProvider image;
+  final VoidCallback onTap;
+  final MediaContentType mediaContentType;
+
+  const MediaLoadedSnippet({
+    Key key,
+    @required this.file,
+    @required this.image,
+    @required this.onTap,
+    @required this.mediaContentType
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.symmetric(vertical: SpacingValues.small),
+      width: MediaQuery.of(context).size.width * 0.75,
+      height: MediaQuery.of(context).size.width * 0.75 * (9 / 16),
+      decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12), color: Colors.grey),
+      child: Material(
+        borderRadius: BorderRadius.circular(12),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: this.onTap,
+          child: Container(
+            decoration: BoxDecoration(
+              image: DecorationImage(image: image, fit: BoxFit.contain)),
+            child: this.mediaContentType !=
+                MediaContentType.VIDEO
+                  ? Container()
+                  : Center(
+                      child: Container(
+                        padding: EdgeInsets.all(SpacingValues.xxSmall),
+                        decoration: BoxDecoration(
+                          color: Colors.grey.withAlpha(200),
+                          shape: BoxShape.circle,
+                        ),
+                        child: Icon(Icons.play_arrow,
+                          color: Colors.white, size: 25),
+                      ),
+                    ),
+            ))),
+    );
+  }
+  
+}

--- a/lib/screens/discussion/media/media_snippet.dart
+++ b/lib/screens/discussion/media/media_snippet.dart
@@ -43,7 +43,7 @@ class _MediaSnippetWidgetState extends State<MediaSnippetWidget> {
   @override
   Widget build(BuildContext context) {
     if (imageFile != null && imageProvider != null) {
-      return MediaLoadedSnippet(
+      return LoadedMediaSnippetWidget(
         mediaContentType: this.widget.post.media?.mediaContentType ??
           this.widget.post.localMediaContentType,
         file: this.imageFile,


### PR DESCRIPTION
This fixes the FOUC issue explained in #96. It was caused by the image snippets, which reloaded the image from the local cache every time the widget tree was rebuilt. This solution adopts a ChangeNotifier object to store the already-loaded images in memory and make them render as a stateless widget.