### PR TITLE
Anonymity switch fix

### DIFF
--- a/lib/bloc/participant/participant_bloc.dart
+++ b/lib/bloc/participant/participant_bloc.dart
@@ -76,6 +76,8 @@ class ParticipantBloc extends Bloc<ParticipantEvent, ParticipantState> {
         // What to do about this error?
         yield ParticipantLoaded(
             participant: currentState.participant, isUpdating: false);
+        if(event.onError != null)
+          event.onError(err);
         return;
       }
       this
@@ -85,6 +87,8 @@ class ParticipantBloc extends Bloc<ParticipantEvent, ParticipantState> {
         participant: updatedParticipant,
         isUpdating: false,
       );
+      if(event.onSuccess != null)
+          event.onSuccess();
     } else if (event is ParticipantEventAddParticipant) {
       yield ParticipantLoaded(participant: null, isUpdating: true);
       final addedParticipant = await this.repository.addDiscussionParticipant(

--- a/lib/bloc/participant/participant_event.dart
+++ b/lib/bloc/participant/participant_event.dart
@@ -24,7 +24,9 @@ class ParticipantEventUpdateParticipant extends ParticipantEvent {
   final bool isAnonymous;
   final bool isUnsetFlairID;
   final bool isUnsetGradient;
-
+  final VoidCallback onSuccess;
+  final Function(dynamic) onError;
+  
   const ParticipantEventUpdateParticipant({
     @required this.participantID,
     this.gradientName,
@@ -32,6 +34,8 @@ class ParticipantEventUpdateParticipant extends ParticipantEvent {
     this.isAnonymous,
     this.isUnsetFlairID,
     this.isUnsetGradient,
+    this.onSuccess,
+    this.onError
   }) : super();
 
   @override

--- a/lib/screens/discussion/discussion_content.dart
+++ b/lib/screens/discussion/discussion_content.dart
@@ -114,7 +114,6 @@ class DiscussionContent extends StatelessWidget {
       this.onOverlayOpen(overlayEntry);
     } else if (this.isShowParticipantSettings) {
       final participantBloc = BlocProvider.of<ParticipantBloc>(context);
-      final notificationBloc = BlocProvider.of<NotificationBloc>(context);
       final overlayEntry = OverlayEntry(
         builder: (context) => AnimatedDiscussionPopup(
           child: Container(width: 0, height: 0),
@@ -125,22 +124,6 @@ class DiscussionContent extends StatelessWidget {
               me: MeBloc.extractMe(BlocProvider.of<MeBloc>(context).state),
               participantBloc: participantBloc,
               onClose: (didUpdate) {
-                if (didUpdate) {
-                  notificationBloc.add(
-                    NewNotificationEvent(
-                      notification: OverlayTopMessage(
-                        child: IncognitoModeTextOverlay(
-                          hasGoneIncognito: didUpdate
-                              ? !this.discussion.meParticipant.isAnonymous
-                              : this.discussion.meParticipant.isAnonymous,
-                        ),
-                        onDismiss: () {
-                          notificationBloc.add(DismissNotification());
-                        },
-                      ),
-                    ),
-                  );
-                }
                 this.onSettingsOverlayClose(didUpdate);
               },
             ),

--- a/lib/screens/discussion/overlay/participant_settings.dart
+++ b/lib/screens/discussion/overlay/participant_settings.dart
@@ -55,13 +55,14 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
   String _selectedFlairID;
   int _selectedIdx;
   _SettingsState _settingsState;
-
+  bool _didChange;
   bool _showLoading;
 
   @override
   void initState() {
     super.initState();
-    this._selectedIdx = 0;
+    this._didChange = false;
+    this._selectedIdx = -1;
     this._settingsState = _SettingsState.ANONYMITY_SELECT;
     this._selectedGradient =
         gradientNameFromString(this.widget.meParticipant?.gradientColor);
@@ -74,7 +75,8 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
     Widget child;
     switch (this._settingsState) {
       case _SettingsState.ANONYMITY_SELECT:
-        Color actionButtonColor = Color.fromRGBO(247, 247, 255, 0.2);
+        bool actionButtonEnabled = _didChange;
+        Color actionButtonColor = _didChange ? Color.fromRGBO(247, 247, 255, 0.2) : Color.fromRGBO(247, 247, 255, 1.0);
         Widget actionButtonText = Text(
           Intl.message('Update'),
           style: TextThemes.goIncognitoButton,
@@ -84,6 +86,7 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
             child: CircularProgressIndicator(),
           );
         } else if (this.widget.settingsFlow == SettingsFlow.JOIN_CHAT) {
+          actionButtonEnabled = true;
           actionButtonColor = Color.fromRGBO(247, 247, 255, 1.0);
           actionButtonText = Text(
             Intl.message('Join'),
@@ -99,7 +102,7 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
               RoundedRectangleBorder(borderRadius: BorderRadius.circular(25.0)),
           color: actionButtonColor,
           child: actionButtonText,
-          onPressed: () {
+          onPressed: !actionButtonEnabled ? null : () {
             if (this.widget.settingsFlow == SettingsFlow.JOIN_CHAT) {
               this.joinDiscussion();
             } else {
@@ -155,6 +158,7 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
             this.setState(() {
               this._selectedFlairID = id;
               this._settingsState = _SettingsState.ANONYMITY_SELECT;
+              this._didChange = true;
             });
           },
           onCancel: () {
@@ -171,6 +175,7 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
             this.setState(() {
               this._selectedGradient = name;
               this._settingsState = _SettingsState.ANONYMITY_SELECT;
+              this._didChange = true;
             });
           },
           onCancel: () {
@@ -270,6 +275,7 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
         onSelected: () {
           setState(() {
             this._selectedIdx = 0;
+            this._didChange = true;
           });
         },
         onEdit: () {
@@ -305,6 +311,7 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
         onSelected: () {
           setState(() {
             this._selectedIdx = 1;
+            this._didChange = true;
           });
         },
         onEdit: onEdit,

--- a/lib/screens/discussion/overlay/participant_settings.dart
+++ b/lib/screens/discussion/overlay/participant_settings.dart
@@ -10,6 +10,7 @@ import 'package:delphis_app/screens/discussion/overlay/participant_anonymity_set
 import 'package:delphis_app/util/callbacks.dart';
 import 'package:delphis_app/util/display_names.dart';
 import 'package:delphis_app/widgets/overlay/overlay_top_message.dart';
+import 'package:delphis_app/widgets/profile_image/profile_image.dart';
 import 'package:delphis_app/widgets/text_overlay_notification/incognito_mode_overlay.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
@@ -386,16 +387,23 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
 
   Widget buildSubTitle() {
     var displayName = DisplayNames.formatParticipant(this.widget.discussion.moderator, this.widget.meParticipant);
+    var profileImage = ProfileImage(
+      height: TextThemes.goIncognitoSubheader.fontSize * 1.3,
+      width: TextThemes.goIncognitoSubheader.fontSize * 1.3,
+      profileImageURL: this.widget.meParticipant.userProfile?.profileImageURL,
+      isAnonymous: this.widget.meParticipant.isAnonymous
+    );
     return RichText(
       textAlign: TextAlign.center,
       text: TextSpan(
         style: TextThemes.goIncognitoSubheader,
-        children: <TextSpan>[
-          TextSpan(text: Intl.message('You currently are ')),
-           TextSpan(text: displayName, style: TextStyle(
-             fontWeight: FontWeight.bold,
-             color: Colors.blue
-           )
+        children: [
+          TextSpan(text: Intl.message('You are currently posting as: ')),
+          WidgetSpan(child: profileImage),
+          TextSpan(text: ' $displayName', style: TextStyle(
+            fontWeight: FontWeight.bold,
+            color: Colors.blue
+          )
           ),
           TextSpan(text: Intl.message('.\nPick how you want your avatar to display.')),
         ],

--- a/lib/screens/discussion/overlay/participant_settings.dart
+++ b/lib/screens/discussion/overlay/participant_settings.dart
@@ -398,12 +398,14 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
       text: TextSpan(
         style: TextThemes.goIncognitoSubheader,
         children: [
-          TextSpan(text: Intl.message('You are currently posting as: ')),
+          TextSpan(text: Intl.message('You are currently posting as:\n')),
           WidgetSpan(child: profileImage),
-          TextSpan(text: ' $displayName', style: TextStyle(
-            fontWeight: FontWeight.bold,
-            color: Colors.blue
-          )
+          TextSpan(
+            text: ' $displayName',
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: Colors.blue
+            )
           ),
           TextSpan(text: Intl.message('.\nPick how you want your avatar to display.')),
         ],

--- a/lib/screens/discussion/overlay/participant_settings.dart
+++ b/lib/screens/discussion/overlay/participant_settings.dart
@@ -8,6 +8,7 @@ import 'package:delphis_app/design/sizes.dart';
 import 'package:delphis_app/design/text_theme.dart';
 import 'package:delphis_app/screens/discussion/overlay/participant_anonymity_setting_option.dart';
 import 'package:delphis_app/util/callbacks.dart';
+import 'package:delphis_app/util/display_names.dart';
 import 'package:delphis_app/widgets/overlay/overlay_top_message.dart';
 import 'package:delphis_app/widgets/text_overlay_notification/incognito_mode_overlay.dart';
 import 'package:flutter/material.dart';
@@ -384,10 +385,21 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
   }
 
   Widget buildSubTitle() {
-    return Text(
-      Intl.message('Pick how you want your avatar to display.'),
-      style: TextThemes.goIncognitoSubheader,
-      textAlign: TextAlign.center
+    var displayName = DisplayNames.formatParticipant(this.widget.discussion.moderator, this.widget.meParticipant);
+    return RichText(
+      textAlign: TextAlign.center,
+      text: TextSpan(
+        style: TextThemes.goIncognitoSubheader,
+        children: <TextSpan>[
+          TextSpan(text: Intl.message('You currently are ')),
+           TextSpan(text: displayName, style: TextStyle(
+             fontWeight: FontWeight.bold,
+             color: Colors.blue
+           )
+          ),
+          TextSpan(text: Intl.message('.\nPick how you want your avatar to display.')),
+        ],
+      ),
     );
   }
 

--- a/lib/widgets/animated_size_container/animated_size_container.dart
+++ b/lib/widgets/animated_size_container/animated_size_container.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class AnimatedSizeContainer extends StatefulWidget {
+  final Duration duration;
+  final Curve curve;
+  final Duration reverseDuration;
+  final Widget Function(BuildContext) builder;
+
+  const AnimatedSizeContainer({
+    Key key,
+    this.duration,
+    this.curve,
+    this.reverseDuration,
+    @required this.builder
+  }) : super(key: key) ;
+  @override
+  _AnimatedSizeContainerState createState() => _AnimatedSizeContainerState();
+}
+
+class _AnimatedSizeContainerState extends State<AnimatedSizeContainer> with SingleTickerProviderStateMixin{
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSize(
+      vsync: this,
+      curve: this.widget.curve ?? Curves.easeInOut,
+      duration: this.widget.duration ?? Duration(milliseconds: 200),
+      reverseDuration: this.widget.reverseDuration ?? Duration(milliseconds: 200),
+      child: this.widget.builder(context),
+    );
+  }
+}

--- a/lib/widgets/input/delphis_input.dart
+++ b/lib/widgets/input/delphis_input.dart
@@ -2,15 +2,18 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:delphis_app/bloc/me/me_bloc.dart';
+import 'package:delphis_app/bloc/participant/participant_bloc.dart';
 import 'package:delphis_app/data/repository/discussion.dart';
 import 'package:delphis_app/data/repository/media.dart';
 import 'package:delphis_app/data/repository/participant.dart';
 import 'package:delphis_app/data/repository/user.dart';
 import 'package:delphis_app/design/sizes.dart';
 import 'package:delphis_app/util/text.dart';
+import 'package:delphis_app/widgets/animated_size_container/animated_size_container.dart';
 import 'package:delphis_app/widgets/input/buttons/discussion_submit_button.dart';
 import 'package:delphis_app/widgets/input/buttons/moderator_input_button.dart';
 import 'package:delphis_app/widgets/settings/participant_settings_button.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -129,15 +132,41 @@ class DelphisInputState extends State<DelphisInput> {
   List<Widget> buildNonInputRowElems(BuildContext context, MeState state,
       User me, bool isModerator, Widget textInput) {
     final rowElems = <Widget>[
-      ParticipantSettingsButton(
-        onPressed: () => this.widget.onParticipantSettingsPressed(
-            this._inputFocusNode.hasFocus ? this._inputFocusNode : null),
-        me: me,
-        isModerator: isModerator,
-        participant: this.widget.participant,
-        discussion: this.widget.discussion,
-        width: 39.0,
-        height: 39.0,
+      AnimatedSizeContainer(
+        builder: (context) {
+          return BlocBuilder<ParticipantBloc, ParticipantState>(
+            builder: (context, participantState) {
+              Widget button = ParticipantSettingsButton(
+                onPressed: () => this.widget.onParticipantSettingsPressed(
+                    this._inputFocusNode.hasFocus ? this._inputFocusNode : null),
+                me: me,
+                isModerator: isModerator,
+                participant: this.widget.participant,
+                discussion: this.widget.discussion,
+                width: 39.0,
+                height: 39.0,
+              );
+
+              if(participantState is ParticipantLoaded && participantState.isUpdating) {
+                button = Stack(
+                  children: [
+                    button,
+                    Positioned.fill(
+                      child: Container(
+                        decoration: BoxDecoration(
+                          color: Colors.black.withOpacity(0.6),
+                        ),
+                        child: CupertinoActivityIndicator(),
+                      ),
+                    )
+                  ],
+                );
+              }
+
+              return button;
+            },
+          );
+        }
       ),
       SizedBox(
         width: SpacingValues.medium,


### PR DESCRIPTION
This tries to target #98. The flashing should be solved by #99, and this PR focuses on making the anonymity switch more responsive.

- The "Update" button is disabled until a selection is made
- The anonymity button now shows an activity indicator when the mutation is still loading
- The anonymity button is not pressable when it is loading
- The notification is showed only when the operation is finished
- Errors in the process are printed in a notification
- Notification last a little longer to allow slow readers to catch up with it
- Animations has been inserted on the button