### PR TITLE
Adding CreateChatBloc

### DIFF
--- a/lib/bloc/create_chat/create_chat_bloc.dart
+++ b/lib/bloc/create_chat/create_chat_bloc.dart
@@ -36,6 +36,38 @@ class CreateChatBloc extends Bloc<CreateChatEvent, CreateChatState> {
         discussionID: event.discussionID,
       );
     } else if (event is SaveCreateChatFlow &&
-        currentState is CreateChatFlowState) {}
+        currentState is CreateChatFlowState) {
+      var currentPage = currentState.currentPage;
+      var nextPage = currentState.nextPage;
+
+      if (event.advanceToNextPage) {
+        currentPage = nextPage;
+        nextPage = CreateChatFlowState.getNextPage(currentPage, null);
+      }
+
+      /*
+      * When entering a page that requires backend communication let's show a 
+      * loading spinner by filling the `isLoading` <- true. Reasonably this 
+      * should be the `INVITE_PAGE` page as well as the `FINISHED` page. The 
+      * first should be fetching whatever is required from the backend to do 
+      * the twitter / Chatham searching. The second is for saving the updated 
+      * discussion and invite lists.
+      */
+
+      if (currentPage == CreateChatPage.FINISHED) {
+        // TODO: Capture loading state here when necessary.
+
+      }
+
+      yield currentState.update(
+        currentPage: currentPage,
+        nextPage: nextPage,
+        title: event.title,
+        description: event.description,
+        chathamInvitedUsers: event.chathamInvitedUsers,
+        twitterInvitedUsers: event.twitterInvitedUsers,
+        isLoading: false,
+      );
+    }
   }
 }

--- a/lib/bloc/create_chat/create_chat_bloc.dart
+++ b/lib/bloc/create_chat/create_chat_bloc.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+
+part 'create_chat_event.dart';
+part 'create_chat_state.dart';
+
+// CreateChat is a slight misnomer here because this bloc is used to track
+// the state while either creating or updating a chat.
+class CreateChatBloc extends Bloc<CreateChatEvent, CreateChatState> {
+  CreateChatBloc() : super(CreateChatFlowNotActive());
+
+  @override
+  Stream<CreateChatState> mapEventToState(
+    CreateChatEvent event,
+  ) async* {
+    final currentState = this.state;
+
+    if (event is StartCreateChatFlow &&
+        currentState is CreateChatFlowNotActive) {
+      yield CreateChatFlowState(
+        currentPage: CreateChatPage.TITLE_AND_DESCRIPTION,
+        nextPage: CreateChatPage.INVITE_INSTRUCTIONS,
+      );
+    } else if (event is StartCreateChatFlowFromPage &&
+        currentState is CreateChatFlowNotActive) {
+      yield CreateChatFlowState(
+        currentPage: event.startPage,
+        nextPage: event.nextPage,
+        title: event.title,
+        description: event.description,
+        chathamInvitedUsers: event.chathamInvitedUsers,
+        twitterInvitedUsers: event.twitterInvitedUsers,
+        discussionID: event.discussionID,
+      );
+    } else if (event is SaveCreateChatFlow &&
+        currentState is CreateChatFlowState) {}
+  }
+}

--- a/lib/bloc/create_chat/create_chat_event.dart
+++ b/lib/bloc/create_chat/create_chat_event.dart
@@ -1,0 +1,77 @@
+part of 'create_chat_bloc.dart';
+
+abstract class CreateChatEvent extends Equatable {
+  const CreateChatEvent();
+}
+
+class StartCreateChatFlow extends CreateChatEvent {
+  final DateTime equatableID;
+
+  const StartCreateChatFlow({@required this.equatableID});
+
+  @override
+  List<Object> get props => [this.equatableID];
+}
+
+class StartCreateChatFlowFromPage extends CreateChatEvent {
+  final DateTime equatableID;
+  final CreateChatPage startPage;
+  final CreateChatPage nextPage;
+  final List<Object> chathamInvitedUsers;
+  final List<Object> twitterInvitedUsers;
+  final String title;
+  final String description;
+  // Use null when this is creating a new discussion. If updating an existing
+  // one fill it in here.
+  final String discussionID;
+
+  const StartCreateChatFlowFromPage({
+    @required this.equatableID,
+    @required this.startPage,
+    @required this.nextPage,
+    @required this.discussionID,
+    this.title,
+    this.description,
+    this.chathamInvitedUsers,
+    this.twitterInvitedUsers,
+  }) : super();
+
+  @override
+  List<Object> get props => [
+        this.equatableID,
+        startPage,
+        nextPage,
+        chathamInvitedUsers,
+        twitterInvitedUsers,
+        title,
+        description
+      ];
+}
+
+class SaveCreateChatFlow extends CreateChatEvent {
+  final DateTime equatableID;
+  final List<Object> chathamInvitedUsers;
+  final List<Object> twitterInvitedUsers;
+  final String title;
+  final String description;
+  final bool advanceToNextPage;
+
+  const SaveCreateChatFlow({
+    @required this.equatableID,
+    @required this.advanceToNextPage,
+    this.title,
+    this.description,
+    this.chathamInvitedUsers,
+    this.twitterInvitedUsers,
+  }) : super();
+
+  @override
+  List<Object> get props => [
+        this.advanceToNextPage,
+        this.equatableID,
+        this.title,
+        this.description,
+        this.chathamInvitedUsers,
+        this.twitterInvitedUsers
+      ];
+}

--- a/lib/bloc/create_chat/create_chat_state.dart
+++ b/lib/bloc/create_chat/create_chat_state.dart
@@ -1,0 +1,99 @@
+part of 'create_chat_bloc.dart';
+
+abstract class CreateChatState extends Equatable {
+  const CreateChatState();
+}
+
+enum CreateChatPage {
+  TITLE_AND_DESCRIPTION,
+  INVITE_INSTRUCTIONS,
+  INVITE_PAGE,
+  CONFIRMATION_PAGE,
+  FINISHED
+}
+
+class CreateChatFlowNotActive extends CreateChatState {
+  const CreateChatFlowNotActive() : super();
+
+  List<Object> get props => [];
+}
+
+class CreateChatFlowState extends CreateChatState {
+  final CreateChatPage currentPage;
+  final CreateChatPage nextPage;
+  final String title;
+  final String description;
+  // TODO: These won't be objects but not sure what types they should be yet.
+  final List<Object> chathamInvitedUsers;
+  final List<Object> twitterInvitedUsers;
+  final String discussionID;
+
+  CreateChatFlowState({
+    this.currentPage,
+    nextPage,
+    this.title,
+    this.description,
+    this.chathamInvitedUsers,
+    this.twitterInvitedUsers,
+    this.discussionID,
+  })  : this.nextPage = CreateChatFlowState.getNextPage(currentPage, nextPage),
+        super();
+
+  static CreateChatPage getNextPage(
+      CreateChatPage currentPage, CreateChatPage nextPage) {
+    if (nextPage != null) {
+      return nextPage;
+    }
+
+    if (currentPage == null) {
+      return null;
+    }
+
+    final values = CreateChatPage.values;
+    final currentIndex = values.indexOf(currentPage);
+    if (currentIndex == -1 || currentIndex == values.length - 1) {
+      return null;
+    }
+
+    return values[currentIndex + 1];
+  }
+
+  @override
+  List<Object> get props => [
+        currentPage,
+        nextPage,
+        title,
+        description,
+        chathamInvitedUsers,
+        twitterInvitedUsers,
+        discussionID,
+      ];
+
+  CreateChatFlowState update({
+    CreateChatPage currentPage,
+    CreateChatPage nextPage,
+    String updatedTitle,
+    String updatedDescription,
+    List<Object> chathamInvitedUsers,
+    List<Object> twitterInvitedUsers,
+  }) {
+    CreateChatPage calculatedNextPage;
+    if (currentPage == null) {
+      calculatedNextPage = nextPage ?? this.nextPage;
+    } else if (nextPage != null) {
+      calculatedNextPage = this.nextPage;
+    } else {
+      calculatedNextPage =
+          CreateChatFlowState.getNextPage(currentPage, nextPage);
+    }
+    return CreateChatFlowState(
+      discussionID: this.discussionID,
+      currentPage: currentPage ?? this.currentPage,
+      nextPage: calculatedNextPage,
+      title: updatedTitle ?? this.title,
+      description: updatedDescription ?? this.description,
+      chathamInvitedUsers: chathamInvitedUsers ?? this.chathamInvitedUsers,
+      twitterInvitedUsers: twitterInvitedUsers ?? this.twitterInvitedUsers,
+    );
+  }
+}

--- a/lib/bloc/create_chat/create_chat_state.dart
+++ b/lib/bloc/create_chat/create_chat_state.dart
@@ -23,10 +23,16 @@ class CreateChatFlowState extends CreateChatState {
   final CreateChatPage nextPage;
   final String title;
   final String description;
-  // TODO: These won't be objects but not sure what types they should be yet.
+  /*
+   * What should the objects for invited users look like? According to 
+   * https://github.com/delphis-inc/delphis_app/pull/108/files for the twitter 
+   * users we can use TwitterUserInput. For Chatham users can we / should we 
+   * use the same? I think it's reasonable to do so.
+   */
   final List<Object> chathamInvitedUsers;
   final List<Object> twitterInvitedUsers;
   final String discussionID;
+  final bool isLoading;
 
   CreateChatFlowState({
     this.currentPage,
@@ -36,6 +42,7 @@ class CreateChatFlowState extends CreateChatState {
     this.chathamInvitedUsers,
     this.twitterInvitedUsers,
     this.discussionID,
+    this.isLoading,
   })  : this.nextPage = CreateChatFlowState.getNextPage(currentPage, nextPage),
         super();
 
@@ -72,10 +79,11 @@ class CreateChatFlowState extends CreateChatState {
   CreateChatFlowState update({
     CreateChatPage currentPage,
     CreateChatPage nextPage,
-    String updatedTitle,
-    String updatedDescription,
+    String title,
+    String description,
     List<Object> chathamInvitedUsers,
     List<Object> twitterInvitedUsers,
+    bool isLoading,
   }) {
     CreateChatPage calculatedNextPage;
     if (currentPage == null) {
@@ -90,10 +98,11 @@ class CreateChatFlowState extends CreateChatState {
       discussionID: this.discussionID,
       currentPage: currentPage ?? this.currentPage,
       nextPage: calculatedNextPage,
-      title: updatedTitle ?? this.title,
-      description: updatedDescription ?? this.description,
+      title: title ?? this.title,
+      description: description ?? this.description,
       chathamInvitedUsers: chathamInvitedUsers ?? this.chathamInvitedUsers,
       twitterInvitedUsers: twitterInvitedUsers ?? this.twitterInvitedUsers,
+      isLoading: isLoading ?? this.isLoading,
     );
   }
 }

--- a/lib/design/colors.dart
+++ b/lib/design/colors.dart
@@ -84,12 +84,10 @@ class GradientStop {
 class ChathamColors {
   static final signInTwitterBackground = Color.fromRGBO(57, 58, 63, 1.0);
   static final twitterLogoColor = Color.fromRGBO(102, 196, 254, 1.0);
+  static final topBarBackgroundColor = Color.fromRGBO(22, 23, 28, 1.0);
 
   static final LinearGradient whiteGradient = LinearGradient(
-    colors: [
-      Colors.white,
-      Colors.white
-    ],
+    colors: [Colors.white, Colors.white],
   );
 
   static final LinearGradient notificationIconGradient = LinearGradient(

--- a/lib/screens/create_chat/base_chat_screen.dart
+++ b/lib/screens/create_chat/base_chat_screen.dart
@@ -1,0 +1,79 @@
+import 'package:delphis_app/design/colors.dart';
+import 'package:delphis_app/design/sizes.dart';
+import 'package:delphis_app/design/text_theme.dart';
+import 'package:delphis_app/screens/home_page/home_page_topbar.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class BaseCreateChatScreen extends StatelessWidget {
+  final Widget contents;
+  final String title;
+
+  final VoidCallback onContinue;
+  final VoidCallback onCancel;
+
+  const BaseCreateChatScreen({
+    @required this.contents,
+    @required this.title,
+    @required this.onContinue,
+    @required this.onCancel,
+  }) : super();
+
+  @override
+  Widget build(BuildContext context) {
+    final windowPadding = MediaQuery.of(context).padding;
+    return Padding(
+      padding: EdgeInsets.only(bottom: windowPadding.bottom),
+      child: Column(
+        children: [
+          Container(
+            height: windowPadding.top,
+            color: ChathamColors.topBarBackgroundColor,
+          ),
+          HomePageTopBar(
+            height: 80.0,
+            title: Intl.message(title),
+            backgroundColor: ChathamColors.topBarBackgroundColor,
+          ),
+          Expanded(
+            child: this.contents,
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              RaisedButton(
+                padding: EdgeInsets.symmetric(
+                  horizontal: SpacingValues.large,
+                  vertical: SpacingValues.medium,
+                ),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(25.0)),
+                color: Color.fromRGBO(247, 247, 255, 0.2),
+                // TODO: This should probably be `Cancel` if it's the first screen.
+                child: Text(Intl.message('Back')),
+                onPressed: this.onCancel,
+              ),
+              RaisedButton(
+                padding: EdgeInsets.symmetric(
+                  horizontal: SpacingValues.xxLarge,
+                  vertical: SpacingValues.medium,
+                ),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(25.0),
+                ),
+                color: Color.fromRGBO(247, 247, 255, 1.0),
+                // TODO: This should probably be `Save` if it's the last screen.
+                child: Text(
+                  Intl.message('Next'),
+                  style: TextThemes.joinButtonTextChatTab,
+                ),
+                onPressed: this.onContinue,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/create_chat/create_chat_screen.dart
+++ b/lib/screens/create_chat/create_chat_screen.dart
@@ -1,0 +1,36 @@
+import 'package:delphis_app/bloc/create_chat/create_chat_bloc.dart';
+import 'package:delphis_app/screens/create_chat/title_and_description.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CreateChatScreen extends StatelessWidget {
+  const CreateChatScreen() : super();
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: Should this Bloc exist above this widget? If not we can be entirely
+    // self contained. However it could lead to some annoyances of interacting
+    // with it.
+    return BlocProvider<CreateChatBloc>(
+        create: (context) => CreateChatBloc(),
+        child: BlocBuilder<CreateChatBloc, CreateChatState>(
+            builder: (context, state) {
+          if (state is CreateChatFlowNotActive) {
+            // We start the flow here!
+            BlocProvider.of<CreateChatBloc>(context)
+                .add(StartCreateChatFlow(equatableID: DateTime.now()));
+            return Container();
+          }
+
+          if (state is CreateChatFlowState) {
+            switch (state.currentPage) {
+              case CreateChatPage.TITLE_AND_DESCRIPTION:
+                return CreateChatTitleAndDescriptionScreen();
+              default:
+                return Container();
+            }
+          }
+          return Container();
+        }));
+  }
+}

--- a/lib/screens/create_chat/title_and_description.dart
+++ b/lib/screens/create_chat/title_and_description.dart
@@ -1,0 +1,124 @@
+import 'package:delphis_app/design/sizes.dart';
+import 'package:delphis_app/design/text_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'base_chat_screen.dart';
+
+typedef void TitleAndDescriptionComplete(String title, String description);
+
+class CreateChatTitleAndDescriptionScreen extends StatefulWidget {
+  static const _headingText =
+      'This lets you create a new conversation for which you will be the moderator. Your identity will be visible to everyone but all participants will be anonymous to each other (and you).';
+
+  final String title;
+  final String description;
+
+  final TitleAndDescriptionComplete onComplete;
+  final VoidCallback onCancel;
+
+  const CreateChatTitleAndDescriptionScreen({
+    @required this.title,
+    @required this.description,
+    @required this.onComplete,
+    @required this.onCancel,
+  }) : super();
+
+  @override
+  State<StatefulWidget> createState() => _CreateChatTitleAndDescriptionScreen();
+}
+
+class _CreateChatTitleAndDescriptionScreen
+    extends State<CreateChatTitleAndDescriptionScreen> {
+  FocusNode _titleFocusNode;
+  TextEditingController _titleInputController;
+
+  FocusNode _descriptionFocusNode;
+  TextEditingController _descriptionInputController;
+
+  @override
+  void initState() {
+    super.initState();
+
+    this._titleFocusNode = FocusNode();
+    this._titleInputController =
+        TextEditingController(text: this.widget.title ?? '');
+
+    this._descriptionFocusNode = FocusNode();
+    this._descriptionInputController =
+        TextEditingController(text: this.widget.description ?? '');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final contents = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(height: SpacingValues.xxLarge),
+        Text(Intl.message(CreateChatTitleAndDescriptionScreen._headingText),
+            style: TextThemes.emojiPickerText),
+        SizedBox(height: SpacingValues.medium),
+        Text(Intl.message('Enter a title for your chat:'),
+            style: TextThemes.discussionPostAuthorAnon),
+        SizedBox(height: SpacingValues.xxSmall),
+        TextField(
+          enabled: true,
+          showCursor: true,
+          focusNode: this._titleFocusNode,
+          controller: this._titleInputController,
+          keyboardType: TextInputType.text,
+          maxLines: 1,
+          decoration: InputDecoration(
+            contentPadding: EdgeInsets.only(
+                left: SpacingValues.smallMedium, bottom: SpacingValues.medium),
+            fillColor: Colors.blue,
+            filled: false,
+          ),
+          style: TextStyle(
+            fontSize: 17.0,
+            fontWeight: FontWeight.w700,
+            height: 1.0,
+            letterSpacing: -0.22,
+          ),
+        ),
+        SizedBox(height: SpacingValues.medium),
+        Text(Intl.message('A description for your chat:'),
+            style: TextThemes.discussionPostAuthorAnon),
+        SizedBox(height: SpacingValues.xxSmall),
+        TextField(
+          enabled: true,
+          showCursor: true,
+          focusNode: this._descriptionFocusNode,
+          controller: this._descriptionInputController,
+          keyboardType: TextInputType.text,
+          maxLines: 1,
+          decoration: InputDecoration(
+            contentPadding: EdgeInsets.only(
+                left: SpacingValues.smallMedium, bottom: SpacingValues.medium),
+            fillColor: Colors.blue,
+            filled: false,
+          ),
+          style: TextStyle(
+            fontSize: 17.0,
+            fontWeight: FontWeight.w700,
+            height: 1.0,
+            letterSpacing: -0.22,
+          ),
+        ),
+      ],
+    );
+
+    return BaseCreateChatScreen(
+      title: "Title and Description",
+      onContinue: () {
+        final title = this._titleInputController.text;
+        final description = this._descriptionInputController.text;
+        if (title != null && title.length > 0) {
+          this.widget.onComplete(title, description);
+        }
+      },
+      onCancel: this.widget.onCancel,
+      contents: contents,
+    );
+  }
+}

--- a/lib/screens/home_page/home_page.dart
+++ b/lib/screens/home_page/home_page.dart
@@ -1,6 +1,7 @@
 import 'package:delphis_app/bloc/discussion/discussion_bloc.dart';
 import 'package:delphis_app/bloc/me/me_bloc.dart';
 import 'package:delphis_app/data/repository/discussion.dart';
+import 'package:delphis_app/design/colors.dart';
 import 'package:delphis_app/screens/discussion/screen_args/discussion.dart';
 import 'package:delphis_app/screens/home_page/chats/chats_screen.dart';
 import 'package:delphis_app/screens/home_page/home_page_topbar.dart';
@@ -34,7 +35,6 @@ class HomePageScreen extends StatefulWidget {
 }
 
 class _HomePageScreenState extends State<HomePageScreen> {
-  final Color _topBarBackgroundColor = Color.fromRGBO(22, 23, 28, 1.0);
   HomePageTab _currentTab;
 
   @override
@@ -66,11 +66,11 @@ class _HomePageScreenState extends State<HomePageScreen> {
             children: [
               Container(
                   height: windowPadding.top,
-                  color: this._topBarBackgroundColor),
+                  color: ChathamColors.topBarBackgroundColor),
               HomePageTopBar(
                   height: 80.0,
                   title: Intl.message('Chats'),
-                  backgroundColor: this._topBarBackgroundColor),
+                  backgroundColor: ChathamColors.topBarBackgroundColor),
               Expanded(
                 child: ChatsScreen(
                   discussionRepository: this.widget.discussionRepository,
@@ -82,7 +82,7 @@ class _HomePageScreenState extends State<HomePageScreen> {
                   ? Container(width: 0, height: 0)
                   : HomePageActionBar(
                       currentTab: this._currentTab,
-                      backgroundColor: this._topBarBackgroundColor,
+                      backgroundColor: ChathamColors.topBarBackgroundColor,
                       onNewChatPressed: () {
                         BlocProvider.of<DiscussionBloc>(context).add(
                           NewDiscussionEvent(


### PR DESCRIPTION
ADDRESSES CHAT-6

This CreateChatBloc has a couple of todos to deal with:

1) What should the objects for invited users look like? According to https://github.com/delphis-inc/delphis_app/pull/108/files for the twitter users we can use `TwitterUserInput`. For Chatham users can we / should we use the same? I think it's reasonable to do so.
2) Loading states -- when entering a page that requires backend communication let's show a loading spinner by filling the `isLoading` <- true. Reasonably this should be the `INVITE_PAGE` page as well as the `FINISHED` page. The first should be fetching whatever is required from the backend to do the twitter / Chatham searching. The second is for saving the updated discussion and invite lists.