### PR TITLE
New chat creation flow and authentication logic

### DIFF
--- a/lib/bloc/auth/auth_bloc.dart
+++ b/lib/bloc/auth/auth_bloc.dart
@@ -60,6 +60,16 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
           } else {
             await launch(url);
           }
+
+          /* Ideally, we need to check the app lifecycle and check that when the
+             app is resumed without a deep link with token. To make it simple,
+             since widgets will get covered by the platform webview, we wait a
+             little and then yield and error state. If the sign in is successful,
+             it will be substituted by a success state when the SetTokenAuthEvent
+             event is fired, and the user will not notice. */
+          await Future.delayed(Duration(seconds: 2));
+          yield ErrorAuthState(
+              "Something went wrong while signing in.\nPlease try again.");
         } else {
           throw 'Could not launch $url';
         }

--- a/lib/bloc/auth/auth_bloc.dart
+++ b/lib/bloc/auth/auth_bloc.dart
@@ -1,38 +1,89 @@
 import 'dart:async';
 
 import 'package:bloc/bloc.dart';
+import 'package:delphis_app/constants.dart';
 import 'package:delphis_app/data/repository/auth.dart';
 import 'package:equatable/equatable.dart';
+import 'package:uni_links/uni_links.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 part 'auth_event.dart';
 part 'auth_state.dart';
 
 class AuthBloc extends Bloc<AuthEvent, AuthState> {
   final DelphisAuthRepository repository;
+  StreamSubscription _deepLinkSubscription;
 
-  AuthBloc(this.repository) : super(InitialAuthState());
+  AuthBloc(this.repository) : super(LoggedOutAuthState()) {
+    _deepLinkSubscription =
+        getLinksStream().listen(this._handleLinkToken, onError: (err) {
+      throw err;
+    });
+  }
+
+  @override
+  Future<void> close() {
+    _deepLinkSubscription?.cancel();
+    return super.close();
+  }
+
+  void _handleLinkToken(String link) {
+    /* Check for Twitter auth token */
+    if (link.startsWith(Constants.twitterRedirectURLPrefix) ||
+        link.startsWith(Constants.twitterRedirectLegacyURLPrefix)) {
+      String token = RegExp("\\?dc=(.*)").firstMatch(link)?.group(1) ?? null;
+      if (token != null) {
+        this.add(SetTokenAuthEvent(token));
+      }
+    }
+  }
 
   @override
   Stream<AuthState> mapEventToState(
     AuthEvent event,
   ) async* {
-    final currentState = this.state;
-    if (event is FetchAuthEvent &&
-        (currentState is InitialAuthState ||
-            currentState is InitializedAuthState)) {
+    var thisState = this.state;
+    if (event is SetTokenAuthEvent) {
+      await closeWebView();
+      this.repository.authString = event.token;
+      yield SignedInAuthState(event.token, true);
+    } else if (event is TwitterSignInAuthEvent) {
+      yield LoadingAuthState();
+      try {
+        var url = Constants.twitterLoginURL;
+        if (await canLaunch(url)) {
+          /* This is needed when the user first signs in with Apple, and then with
+             Twitter.*/
+          if (thisState is SignedInAuthState) {
+            await launch(url,
+                headers: {"Authorization": "Bearer ${thisState.authString}"});
+          } else {
+            await launch(url);
+          }
+        } else {
+          throw 'Could not launch $url';
+        }
+      } catch (err) {
+        yield ErrorAuthState(err);
+      }
+    } else if (event is AppleSignInAuthEvent) {
+      /* TODO: This event is unhandled because all the Apple authentication
+         flow is encoded the SignInWithAppleButton widget.
+         This is not the best practice but it serves its purpose for now, future
+         refactorings will need to encode the Apple auth flow in this BLoC too.
+      */
+    } else if (event is LocalSignInAuthEvent) {
       yield LoadingAuthState();
       final isAuthed = await this.repository.loadFromStorage();
-      yield InitializedAuthState(this.repository.authString, isAuthed);
-    } else if (event is LoadedAuthEvent) {
-      if (event.isSuccess) {
-        this.repository.authString = event.authString;
+      if (isAuthed) {
+        yield SignedInAuthState(this.repository.authString, true);
+      } else {
+        yield LoggedOutAuthState();
       }
-      yield InitializedAuthState(event.authString, event.isSuccess);
     } else if (event is LogoutAuthEvent) {
+      yield LoadingAuthState();
       await this.repository.logout();
-      // We yield this to ensure the app shows the logged out views.
       yield LoggedOutAuthState();
-      yield InitializedAuthState(null, false);
     }
   }
 }

--- a/lib/bloc/auth/auth_event.dart
+++ b/lib/bloc/auth/auth_event.dart
@@ -4,25 +4,31 @@ abstract class AuthEvent extends Equatable {
   const AuthEvent();
 }
 
-class FetchAuthEvent extends AuthEvent {
+class TwitterSignInAuthEvent extends AuthEvent {
   @override
   List<Object> get props => [];
 }
 
-class LoadedAuthEvent extends AuthEvent {
-  final String authString;
-  final bool isSuccess;
-  final bool isFromLocalStorage;
-
-  const LoadedAuthEvent(
-      this.authString, this.isSuccess, this.isFromLocalStorage)
-      : super();
-
+class AppleSignInAuthEvent extends AuthEvent {
   @override
-  List<Object> get props => [this.authString, this.isSuccess];
+  List<Object> get props => [];
+}
+
+class LocalSignInAuthEvent extends AuthEvent {
+  @override
+  List<Object> get props => [];
 }
 
 class LogoutAuthEvent extends AuthEvent {
   @override
   List<Object> get props => [];
+}
+
+class SetTokenAuthEvent extends AuthEvent {
+  final String token;
+
+  SetTokenAuthEvent(this.token);
+
+  @override
+  List<Object> get props => [token];
 }

--- a/lib/bloc/auth/auth_state.dart
+++ b/lib/bloc/auth/auth_state.dart
@@ -4,27 +4,34 @@ abstract class AuthState extends Equatable {
   const AuthState();
 }
 
-class InitialAuthState extends AuthState {
+class LoggedOutAuthState extends AuthState {
   @override
   List<Object> get props => [];
 }
 
 class LoadingAuthState extends AuthState {
+  final DateTime timestamp = DateTime.now();
   @override
-  List<Object> get props => [];
+  List<Object> get props => [timestamp];
 }
 
-class InitializedAuthState extends AuthState {
+class ErrorAuthState extends AuthState {
+  final DateTime timestamp = DateTime.now();
+  final error;
+
+  ErrorAuthState(this.error);
+
+  @override
+  List<Object> get props => [error, timestamp];
+}
+
+class SignedInAuthState extends AuthState {
+  final DateTime timestamp = DateTime.now();
   final String authString;
-  final bool isAuthed;
+  final bool isLocal;
 
-  const InitializedAuthState(this.authString, this.isAuthed) : super();
+  SignedInAuthState(this.authString, this.isLocal) : super();
 
   @override
-  List<Object> get props => [this.authString, this.isAuthed];
-}
-
-class LoggedOutAuthState extends AuthState {
-  @override
-  List<Object> get props => [];
+  List<Object> get props => [this.authString, this.isLocal, this.timestamp];
 }

--- a/lib/bloc/discussion/discussion_bloc.dart
+++ b/lib/bloc/discussion/discussion_bloc.dart
@@ -382,7 +382,10 @@ class DiscussionBloc extends Bloc<DiscussionEvent, DiscussionState> {
           anonymityType: event.anonymityType, title: event.title);
       try {
         final discussion = await this.discussionRepository.createDiscussion(
-            title: event.title, anonymityType: event.anonymityType);
+              title: event.title,
+              description: event.description,
+              anonymityType: event.anonymityType,
+            );
         yield DiscussionLoadedState(
             discussion: discussion,
             lastUpdate: DateTime.now(),

--- a/lib/bloc/discussion/discussion_bloc.dart
+++ b/lib/bloc/discussion/discussion_bloc.dart
@@ -376,24 +376,12 @@ class DiscussionBloc extends Bloc<DiscussionEvent, DiscussionState> {
         discussion: currentState.discussion,
         localPosts: currentState.localPosts,
       );
-    } else if (event is NewDiscussionEvent) {
-      final originalState = currentState;
-      yield AddingDiscussionState(
-          anonymityType: event.anonymityType, title: event.title);
-      try {
-        final discussion = await this.discussionRepository.createDiscussion(
-              title: event.title,
-              description: event.description,
-              anonymityType: event.anonymityType,
-            );
-        yield DiscussionLoadedState(
-            discussion: discussion,
-            lastUpdate: DateTime.now(),
-            onboardingConciergeStep: getConciergeStep(discussion));
-      } catch (err) {
-        // TODO: We should probably say that we failed somewhere.
-        yield originalState;
-      }
+    } else if (event is LoadLocalDiscussionEvent) {
+      // This might be used for local cached copies too eventually
+      yield DiscussionLoadedState(
+          discussion: event.discussion,
+          lastUpdate: DateTime.now(),
+          onboardingConciergeStep: getConciergeStep(event.discussion));
     } else if (event is DiscussionConciergeOptionSelectedEvent &&
         currentState is DiscussionLoadedState &&
         currentState.discussion.id == event.discussionID) {

--- a/lib/bloc/discussion/discussion_bloc.dart
+++ b/lib/bloc/discussion/discussion_bloc.dart
@@ -438,6 +438,7 @@ class DiscussionBloc extends Bloc<DiscussionEvent, DiscussionState> {
             .updateDiscussion(
                 event.discussionID,
                 event.title,
+                event.description,
                 event.selectedEmoji == null
                     ? null
                     : "emoji://${event.selectedEmoji}");

--- a/lib/bloc/discussion/discussion_event.dart
+++ b/lib/bloc/discussion/discussion_event.dart
@@ -179,14 +179,16 @@ class RefreshPostsEvent extends DiscussionEvent {
 
 class NewDiscussionEvent extends DiscussionEvent {
   final String title;
+  final String description;
   final AnonymityType anonymityType;
   final String nonce;
 
-  NewDiscussionEvent(
-      {@required this.title,
-      @required this.anonymityType,
-      @required this.nonce})
-      : super();
+  NewDiscussionEvent({
+    @required this.title,
+    @required this.description,
+    @required this.anonymityType,
+    @required this.nonce,
+  }) : super();
 
   @override
   List<Object> get props => [this.nonce];

--- a/lib/bloc/discussion/discussion_event.dart
+++ b/lib/bloc/discussion/discussion_event.dart
@@ -177,21 +177,13 @@ class RefreshPostsEvent extends DiscussionEvent {
   List<Object> get props => [this.discussionID, this.now];
 }
 
-class NewDiscussionEvent extends DiscussionEvent {
-  final String title;
-  final String description;
-  final AnonymityType anonymityType;
-  final String nonce;
+class LoadLocalDiscussionEvent extends DiscussionEvent {
+  final Discussion discussion;
 
-  NewDiscussionEvent({
-    @required this.title,
-    @required this.description,
-    @required this.anonymityType,
-    @required this.nonce,
-  }) : super();
+  LoadLocalDiscussionEvent({@required this.discussion});
 
   @override
-  List<Object> get props => [this.nonce];
+  List<Object> get props => [this.discussion];
 }
 
 class LoadPreviousPostsPageEvent extends DiscussionEvent {

--- a/lib/bloc/discussion/discussion_event.dart
+++ b/lib/bloc/discussion/discussion_event.dart
@@ -235,9 +235,11 @@ class DiscussionUpdateEvent extends DiscussionEvent {
   final String discussionID;
   final String title;
   final String selectedEmoji;
+  final String description;
 
   DiscussionUpdateEvent({
     @required this.title,
+    @required this.description,
     @required this.discussionID,
     @required this.selectedEmoji,
   }) : super();

--- a/lib/bloc/discussion/discussion_state.dart
+++ b/lib/bloc/discussion/discussion_state.dart
@@ -77,18 +77,3 @@ class DiscussionLoadedState extends DiscussionState {
   @override
   List<Object> get props => [this.discussion, this.lastUpdate, this.isLoading];
 }
-
-class AddingDiscussionState extends DiscussionState {
-  final String title;
-  final AnonymityType anonymityType;
-
-  AddingDiscussionState({@required this.title, @required this.anonymityType})
-      : super();
-
-  Discussion getDiscussion() {
-    return null;
-  }
-
-  @override
-  List<Object> get props => [this.title, this.anonymityType];
-}

--- a/lib/bloc/observer.dart
+++ b/lib/bloc/observer.dart
@@ -3,7 +3,6 @@ import 'package:bloc/bloc.dart';
 class ChathamBlocObserver extends BlocObserver {
   @override
   void onTransition(Bloc bloc, Transition transition) {
-    print("$bloc, $transition");
     super.onTransition(bloc, transition);
   }
 }

--- a/lib/bloc/observer.dart
+++ b/lib/bloc/observer.dart
@@ -3,6 +3,7 @@ import 'package:bloc/bloc.dart';
 class ChathamBlocObserver extends BlocObserver {
   @override
   void onTransition(Bloc bloc, Transition transition) {
+    print("$bloc, $transition");
     super.onTransition(bloc, transition);
   }
 }

--- a/lib/bloc/upsert_chat/upsert_discussion_bloc.dart
+++ b/lib/bloc/upsert_chat/upsert_discussion_bloc.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:bloc/bloc.dart';
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_info.dart';
 import 'package:delphis_app/data/repository/discussion.dart';
+import 'package:delphis_app/data/repository/discussion_creation_settings.dart';
 import 'package:delphis_app/data/repository/user.dart';
 import 'package:equatable/equatable.dart';
 import 'package:intl/intl.dart';
@@ -13,7 +14,6 @@ part 'upsert_discussion_state.dart';
 class UpsertDiscussionBloc
     extends Bloc<UpsertDiscussionEvent, UpsertDiscussionState> {
   final DiscussionRepository discussionRepository;
-  var attempt = 0;
 
   UpsertDiscussionBloc(this.discussionRepository)
       : super(UpsertDiscussionReadyState(UpsertDiscussionInfo()));
@@ -55,28 +55,18 @@ class UpsertDiscussionBloc
           return;
         }
 
-        /* The real call must be updated on the backend to support the new flow:
-             + description
-             + inviteMode
-             - anonymityMode (?) */
-        // final discussion = await this.discussionRepository.createDiscussion(
-        //       title: this.state.info.title,
-        //       description: this.state.info.description,
-        //       anonymityType: AnonymityType.WEAK,
-        //     );
-
-        /* This is mocked for UI development */
-        await Future.delayed(Duration(seconds: 2));
-        // yield UpsertDiscussionErrorState(
-        //     this.state.info, "Something went wrong.");
-        if (attempt++ > 1)
-          yield UpsertDiscussionReadyState(info.copyWith(
-              discussion:
-                  Discussion(id: "34bbaab2-eee8-4b64-bbfa-e4c4f71ae5a6"),
-              inviteLink:
-                  "https://docs.flutter.io/flutter/services/UrlLauncher-class.html"));
-        else
-          throw "This is an error example for any kind of problem that may occur";
+        final discussion = await this.discussionRepository.createDiscussion(
+            title: info.title,
+            description: info.description,
+            anonymityType: AnonymityType.WEAK,
+            creationSettings: DiscussionCreationSettings(
+              discussionJoinability: info.inviteMode,
+            ));
+        yield UpsertDiscussionReadyState(info.copyWith(
+          discussion: discussion,
+          isNewDiscussion: false,
+          inviteLink: discussion.discussionLinksAccess.inviteLinkURL,
+        ));
       } catch (error) {
         yield UpsertDiscussionErrorState(this.state.info, error);
       }

--- a/lib/bloc/upsert_chat/upsert_discussion_bloc.dart
+++ b/lib/bloc/upsert_chat/upsert_discussion_bloc.dart
@@ -13,6 +13,7 @@ part 'upsert_discussion_state.dart';
 class UpsertDiscussionBloc
     extends Bloc<UpsertDiscussionEvent, UpsertDiscussionState> {
   final DiscussionRepository discussionRepository;
+  var attempt = 0;
 
   UpsertDiscussionBloc(this.discussionRepository)
       : super(UpsertDiscussionReadyState(UpsertDiscussionInfo()));
@@ -61,11 +62,16 @@ class UpsertDiscussionBloc
 
         /* This is mocked for UI development */
         await Future.delayed(Duration(seconds: 2));
-        final Discussion discussion = Discussion();
-        final updated = this.state.info.copyWith(
-            discussion: discussion,
-            inviteLink: "This is a test invitation link");
-        yield UpsertDiscussionReadyState(updated);
+        // yield UpsertDiscussionErrorState(
+        //     this.state.info, "Something went wrong.");
+        if (attempt++ > 1)
+          yield UpsertDiscussionReadyState(this.state.info.copyWith(
+              discussion:
+                  Discussion(id: "34bbaab2-eee8-4b64-bbfa-e4c4f71ae5a6"),
+              inviteLink:
+                  "https://docs.flutter.io/flutter/services/UrlLauncher-class.html"));
+        else
+          throw "This is an error example for any kind of problem that may occur";
       } catch (error) {
         yield UpsertDiscussionErrorState(this.state.info, error);
       }

--- a/lib/bloc/upsert_chat/upsert_discussion_bloc.dart
+++ b/lib/bloc/upsert_chat/upsert_discussion_bloc.dart
@@ -45,19 +45,22 @@ class UpsertDiscussionBloc
           yield UpsertDiscussionErrorState(this.state.info,
               Intl.message("You didn't insert all the required fields"));
         }
+
         /* The real call must be updated on the backend to support the new flow:
              + description
              + inviteMode
-             - anonymityMode (?)
-        */
-        // final discussion = await this
-        //     .discussionRepository
-        //     .createDiscussion(title: this.state.info.title);
+             - anonymityMode (?) */
+        // final discussion = await this.discussionRepository.createDiscussion(
+        //       title: this.state.info.title,
+        //       description: this.state.info.description,
+        //       anonymityType: AnonymityType.WEAK,
+        //     );
 
         /* This is mocked for UI development */
         await Future.delayed(Duration(seconds: 2));
+        final Discussion discussion = Discussion();
         final updated = this.state.info.copyWith(
-            discussion: Discussion(),
+            discussion: discussion,
             inviteLink: "This is a test invitation link");
         yield UpsertDiscussionReadyState(updated);
       } catch (error) {

--- a/lib/bloc/upsert_chat/upsert_discussion_bloc.dart
+++ b/lib/bloc/upsert_chat/upsert_discussion_bloc.dart
@@ -50,9 +50,7 @@ class UpsertDiscussionBloc
       yield UpsertDiscussionCreateLoadingState(info);
       try {
         if (((info.title?.length ?? 0) == 0) || info.inviteMode == null) {
-          yield UpsertDiscussionErrorState(
-              info, Intl.message("You didn't insert all the required fields"));
-          return;
+          throw Intl.message("You didn't insert all the required fields");
         }
 
         final discussion = await this.discussionRepository.createDiscussion(

--- a/lib/bloc/upsert_chat/upsert_discussion_bloc.dart
+++ b/lib/bloc/upsert_chat/upsert_discussion_bloc.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_info.dart';
+import 'package:delphis_app/data/repository/discussion.dart';
+import 'package:delphis_app/data/repository/user.dart';
+import 'package:equatable/equatable.dart';
+import 'package:intl/intl.dart';
+
+part 'upsert_discussion_event.dart';
+part 'upsert_discussion_state.dart';
+
+class UpsertDiscussionBloc
+    extends Bloc<UpsertDiscussionEvent, UpsertDiscussionState> {
+  final DiscussionRepository discussionRepository;
+
+  UpsertDiscussionBloc(this.discussionRepository)
+      : super(UpsertDiscussionReadyState(UpsertDiscussionInfo()));
+
+  @override
+  Stream<UpsertDiscussionState> mapEventToState(
+    UpsertDiscussionEvent event,
+  ) async* {
+    if (this.state is UpsertDiscussionLoadingState) {
+      /* We don't want anything to happen while something is loading.
+         it would be dangerous and treath state consistency. */
+    } else if (event is UpsertDiscussionMeUserChangeEvent) {
+      final updated = this.state.info.copyWith(meUser: event.me);
+      yield UpsertDiscussionReadyState(updated);
+    } else if (event is UpsertDiscussionSelectDiscussionEvent) {
+      final updated = this.state.info.copyWith(discussion: event.discussion);
+      yield UpsertDiscussionReadyState(updated);
+    } else if (event is UpsertDiscussionSetInfoEvent) {
+      final updated = this.state.info.copyWith(
+          title: event.title,
+          description: event.description,
+          inviteMode: event.inviteMode);
+      yield UpsertDiscussionReadyState(updated);
+    } else if (event is UpsertDiscussionCreateDiscussionEvent) {
+      yield UpsertDiscussionCreateLoadingState(this.state.info);
+      try {
+        if ((this.state.info.title?.length == 0 ?? true) ||
+            this.state.info.description == null ||
+            this.state.info.inviteMode == null) {
+          yield UpsertDiscussionErrorState(this.state.info,
+              Intl.message("You didn't insert all the required fields"));
+        }
+        /* The real call must be updated on the backend to support the new flow:
+             + description
+             + inviteMode
+             - anonymityMode (?)
+        */
+        // final discussion = await this
+        //     .discussionRepository
+        //     .createDiscussion(title: this.state.info.title);
+
+        /* This is mocked for UI development */
+        await Future.delayed(Duration(seconds: 2));
+        final updated = this.state.info.copyWith(
+            discussion: Discussion(),
+            inviteLink: "This is a test invitation link");
+        yield UpsertDiscussionReadyState(updated);
+      } catch (error) {
+        yield UpsertDiscussionErrorState(this.state.info, error);
+      }
+    }
+  }
+}

--- a/lib/bloc/upsert_chat/upsert_discussion_bloc.dart
+++ b/lib/bloc/upsert_chat/upsert_discussion_bloc.dart
@@ -28,7 +28,10 @@ class UpsertDiscussionBloc
       final updated = this.state.info.copyWith(meUser: event.me);
       yield UpsertDiscussionReadyState(updated);
     } else if (event is UpsertDiscussionSelectDiscussionEvent) {
-      final updated = this.state.info.copyWith(discussion: event.discussion);
+      final updated = this.state.info.copyWith(
+            discussion: event.discussion,
+            isNewDiscussion: false,
+          );
       yield UpsertDiscussionReadyState(updated);
     } else if (event is UpsertDiscussionSetInfoEvent) {
       final updated = this.state.info.copyWith(

--- a/lib/bloc/upsert_chat/upsert_discussion_event.dart
+++ b/lib/bloc/upsert_chat/upsert_discussion_event.dart
@@ -38,15 +38,26 @@ class UpsertDiscussionCreateDiscussionEvent extends UpsertDiscussionEvent {
 }
 
 /* Whenever a user wants to set some data fields of the fields in the current
-   editing/creation state. NOTE: Only non-null fields will be considered. */
-class UpsertDiscussionSetInfoEvent extends UpsertDiscussionEvent {
+   editing/creation state. */
+class UpsertDiscussionSetTitleDescriptionEvent extends UpsertDiscussionEvent {
   final DateTime timestamp = DateTime.now();
   final String title;
   final String description;
-  final DiscussionInviteMode inviteMode;
 
-  UpsertDiscussionSetInfoEvent({this.title, this.description, this.inviteMode});
+  UpsertDiscussionSetTitleDescriptionEvent({this.title, this.description});
 
   @override
-  List<Object> get props => [timestamp, title, description, inviteMode];
+  List<Object> get props => [timestamp, title, description];
+}
+
+/* Whenever a user wants to set some data fields of the fields in the current
+   editing/creation state. */
+class UpsertDiscussionSetInviteModeEvent extends UpsertDiscussionEvent {
+  final DateTime timestamp = DateTime.now();
+  final DiscussionJoinabilitySetting inviteMode;
+
+  UpsertDiscussionSetInviteModeEvent({this.inviteMode});
+
+  @override
+  List<Object> get props => [timestamp, inviteMode];
 }

--- a/lib/bloc/upsert_chat/upsert_discussion_event.dart
+++ b/lib/bloc/upsert_chat/upsert_discussion_event.dart
@@ -1,0 +1,52 @@
+part of 'upsert_discussion_bloc.dart';
+
+abstract class UpsertDiscussionEvent extends Equatable {
+  const UpsertDiscussionEvent();
+}
+
+/* Whenever the authed user changes */
+class UpsertDiscussionMeUserChangeEvent extends UpsertDiscussionEvent {
+  final DateTime timestamp = DateTime.now();
+  final User me;
+
+  UpsertDiscussionMeUserChangeEvent(this.me);
+
+  @override
+  List<Object> get props => [timestamp, me];
+}
+
+/* Whenever a discussion gets selected to be edited/updated */
+class UpsertDiscussionSelectDiscussionEvent extends UpsertDiscussionEvent {
+  final DateTime timestamp = DateTime.now();
+  final Discussion discussion;
+
+  UpsertDiscussionSelectDiscussionEvent(this.discussion);
+
+  @override
+  List<Object> get props => [timestamp, discussion];
+}
+
+/* Whenever a the user wants to finalize a new discussion creation
+   with the current BLoC state configuration */
+class UpsertDiscussionCreateDiscussionEvent extends UpsertDiscussionEvent {
+  final DateTime timestamp = DateTime.now();
+
+  UpsertDiscussionCreateDiscussionEvent();
+
+  @override
+  List<Object> get props => [timestamp];
+}
+
+/* Whenever a user wants to set some data fields of the fields in the current
+   editing/creation state. NOTE: Only non-null fields will be considered. */
+class UpsertDiscussionSetInfoEvent extends UpsertDiscussionEvent {
+  final DateTime timestamp = DateTime.now();
+  final String title;
+  final String description;
+  final DiscussionInviteMode inviteMode;
+
+  UpsertDiscussionSetInfoEvent({this.title, this.description, this.inviteMode});
+
+  @override
+  List<Object> get props => [timestamp, title, description, inviteMode];
+}

--- a/lib/bloc/upsert_chat/upsert_discussion_info.dart
+++ b/lib/bloc/upsert_chat/upsert_discussion_info.dart
@@ -1,0 +1,52 @@
+import 'package:delphis_app/data/repository/discussion.dart';
+import 'package:delphis_app/data/repository/user.dart';
+import 'package:equatable/equatable.dart';
+
+enum DiscussionInviteMode { EVERYONE_FOLLOWED, EVERYONE_APPROVED }
+
+class UpsertDiscussionInfo extends Equatable {
+  final User meUser;
+  final Discussion discussion;
+  final String title;
+  final String description;
+  final DiscussionInviteMode inviteMode;
+  final String inviteLink;
+  final bool isNewDiscussion;
+
+  UpsertDiscussionInfo(
+      {this.meUser,
+      this.discussion,
+      this.title,
+      this.description,
+      this.inviteMode,
+      this.inviteLink,
+      this.isNewDiscussion});
+
+  UpsertDiscussionInfo copyWith(
+      {meUser,
+      discussion,
+      title,
+      description,
+      inviteMode,
+      inviteLink,
+      isNewDiscussion}) {
+    return UpsertDiscussionInfo(
+        meUser: meUser ?? this.meUser,
+        discussion: discussion ?? this.discussion,
+        title: title ?? this.title,
+        description: description ?? this.description,
+        inviteMode: inviteMode ?? this.inviteMode,
+        inviteLink: inviteLink ?? this.inviteLink,
+        isNewDiscussion: isNewDiscussion ?? this.isNewDiscussion);
+  }
+
+  @override
+  List<Object> get props => [
+        this.discussion,
+        this.title,
+        this.description,
+        this.inviteMode,
+        this.inviteLink,
+        this.isNewDiscussion
+      ];
+}

--- a/lib/bloc/upsert_chat/upsert_discussion_info.dart
+++ b/lib/bloc/upsert_chat/upsert_discussion_info.dart
@@ -13,23 +13,25 @@ class UpsertDiscussionInfo extends Equatable {
   final String inviteLink;
   final bool isNewDiscussion;
 
-  UpsertDiscussionInfo(
-      {this.meUser,
-      this.discussion,
-      this.title,
-      this.description,
-      this.inviteMode,
-      this.inviteLink,
-      this.isNewDiscussion});
+  UpsertDiscussionInfo({
+    this.meUser,
+    this.discussion,
+    this.title,
+    this.description,
+    this.inviteMode,
+    this.inviteLink,
+    this.isNewDiscussion = true,
+  });
 
-  UpsertDiscussionInfo copyWith(
-      {meUser,
-      discussion,
-      title,
-      description,
-      inviteMode,
-      inviteLink,
-      isNewDiscussion}) {
+  UpsertDiscussionInfo copyWith({
+    meUser,
+    discussion,
+    title,
+    description,
+    inviteMode,
+    inviteLink,
+    isNewDiscussion,
+  }) {
     return UpsertDiscussionInfo(
         meUser: meUser ?? this.meUser,
         discussion: discussion ?? this.discussion,

--- a/lib/bloc/upsert_chat/upsert_discussion_info.dart
+++ b/lib/bloc/upsert_chat/upsert_discussion_info.dart
@@ -2,14 +2,12 @@ import 'package:delphis_app/data/repository/discussion.dart';
 import 'package:delphis_app/data/repository/user.dart';
 import 'package:equatable/equatable.dart';
 
-enum DiscussionInviteMode { EVERYONE_FOLLOWED, EVERYONE_APPROVED }
-
 class UpsertDiscussionInfo extends Equatable {
   final User meUser;
   final Discussion discussion;
   final String title;
   final String description;
-  final DiscussionInviteMode inviteMode;
+  final DiscussionJoinabilitySetting inviteMode;
   final String inviteLink;
   final bool isNewDiscussion;
 
@@ -31,15 +29,18 @@ class UpsertDiscussionInfo extends Equatable {
     inviteMode,
     inviteLink,
     isNewDiscussion,
+    bool overrideDescription = false,
   }) {
     return UpsertDiscussionInfo(
-        meUser: meUser ?? this.meUser,
-        discussion: discussion ?? this.discussion,
-        title: title ?? this.title,
-        description: description ?? this.description,
-        inviteMode: inviteMode ?? this.inviteMode,
-        inviteLink: inviteLink ?? this.inviteLink,
-        isNewDiscussion: isNewDiscussion ?? this.isNewDiscussion);
+      meUser: meUser ?? this.meUser,
+      discussion: discussion ?? this.discussion,
+      title: title ?? this.title,
+      description:
+          description ?? (overrideDescription ? description : this.description),
+      inviteMode: inviteMode ?? this.inviteMode,
+      inviteLink: inviteLink ?? this.inviteLink,
+      isNewDiscussion: isNewDiscussion ?? this.isNewDiscussion,
+    );
   }
 
   @override

--- a/lib/bloc/upsert_chat/upsert_discussion_state.dart
+++ b/lib/bloc/upsert_chat/upsert_discussion_state.dart
@@ -31,7 +31,7 @@ class UpsertDiscussionReadyState extends UpsertDiscussionState {
   List<Object> get props => [info, timestamp];
 }
 
-class UpsertDiscussionCreateLoadingState extends UpsertDiscussionState {
+class UpsertDiscussionCreateLoadingState extends UpsertDiscussionLoadingState {
   final DateTime timestamp = DateTime.now();
   final UpsertDiscussionInfo info;
 

--- a/lib/bloc/upsert_chat/upsert_discussion_state.dart
+++ b/lib/bloc/upsert_chat/upsert_discussion_state.dart
@@ -1,0 +1,42 @@
+part of 'upsert_discussion_bloc.dart';
+
+abstract class UpsertDiscussionState extends Equatable {
+  UpsertDiscussionInfo get info;
+}
+
+abstract class UpsertDiscussionLoadingState extends UpsertDiscussionState {
+  DateTime get timestamp;
+
+  List<Object> get props => [timestamp, info];
+}
+
+class UpsertDiscussionErrorState extends UpsertDiscussionState {
+  final DateTime timestamp = DateTime.now();
+  final UpsertDiscussionInfo info;
+  final error;
+
+  UpsertDiscussionErrorState(this.info, this.error);
+
+  @override
+  List<Object> get props => [timestamp, info, error];
+}
+
+class UpsertDiscussionReadyState extends UpsertDiscussionState {
+  final DateTime timestamp = DateTime.now();
+  final UpsertDiscussionInfo info;
+
+  UpsertDiscussionReadyState(this.info);
+
+  @override
+  List<Object> get props => [info, timestamp];
+}
+
+class UpsertDiscussionCreateLoadingState extends UpsertDiscussionState {
+  final DateTime timestamp = DateTime.now();
+  final UpsertDiscussionInfo info;
+
+  UpsertDiscussionCreateLoadingState(this.info);
+
+  @override
+  List<Object> get props => [info, timestamp];
+}

--- a/lib/chatham_app.dart
+++ b/lib/chatham_app.dart
@@ -435,7 +435,7 @@ class ChathamAppState extends State<ChathamApp>
                           child: BlocListener<DiscussionBloc, DiscussionState>(
                             listener: (context, state) {
                               if (state.getDiscussion()?.id ==
-                                  arguments.discussion.id) {
+                                  arguments.discussion?.id) {
                                 BlocProvider.of<UpsertDiscussionBloc>(context)
                                     .add(UpsertDiscussionSelectDiscussionEvent(
                                         state.getDiscussion()));

--- a/lib/chatham_app.dart
+++ b/lib/chatham_app.dart
@@ -427,14 +427,15 @@ class ChathamAppState extends State<ChathamApp>
                                 MeBloc.extractMe(
                                     BlocProvider.of<MeBloc>(context).state)))
                             ..add(UpsertDiscussionSelectDiscussionEvent(
-                                BlocProvider.of<DiscussionBloc>(context)
-                                    .state
-                                    .getDiscussion())),
+                                arguments.discussion)),
                           child: BlocListener<DiscussionBloc, DiscussionState>(
                             listener: (context, state) {
-                              BlocProvider.of<UpsertDiscussionBloc>(context)
-                                  .add(UpsertDiscussionSelectDiscussionEvent(
-                                      state.getDiscussion()));
+                              if (state.getDiscussion()?.id ==
+                                  arguments.discussion.id) {
+                                BlocProvider.of<UpsertDiscussionBloc>(context)
+                                    .add(UpsertDiscussionSelectDiscussionEvent(
+                                        state.getDiscussion()));
+                              }
                             },
                             child: BlocListener<MeBloc, MeState>(
                               listener: (context, state) {

--- a/lib/chatham_app.dart
+++ b/lib/chatham_app.dart
@@ -6,12 +6,14 @@ import 'package:delphis_app/bloc/discussion_list/discussion_list_bloc.dart';
 import 'package:delphis_app/bloc/gql_client/gql_client_bloc.dart';
 import 'package:delphis_app/bloc/mention/mention_bloc.dart';
 import 'package:delphis_app/bloc/superpowers/superpowers_bloc.dart';
+import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
 import 'package:delphis_app/data/repository/discussion.dart';
 import 'package:delphis_app/data/repository/media.dart';
-import 'package:delphis_app/data/repository/twitter_user.dart';
 import 'package:delphis_app/data/repository/user.dart';
 import 'package:delphis_app/screens/auth/base/sign_in.dart';
 import 'package:delphis_app/screens/discussion/naming_discussion.dart';
+import 'package:delphis_app/screens/upsert_discussion/screen_arguments.dart';
+import 'package:delphis_app/screens/upsert_discussion/upsert_discussion_screen.dart';
 import 'package:delphis_app/util/link.dart';
 import 'package:delphis_app/util/route_observer.dart';
 import 'package:delphis_app/widgets/overlay/overlay_top_message.dart';
@@ -410,6 +412,41 @@ class ChathamAppState extends State<ChathamApp>
                             onClosePressed: (context) {
                               Navigator.pop(context);
                             }));
+                    break;
+                  case '/Discussion/Upsert':
+                    UpsertDiscussionArguments arguments =
+                        settings.arguments as UpsertDiscussionArguments;
+                    return PageTransition(
+                        settings: settings,
+                        type: PageTransitionType.rightToLeft,
+                        child: BlocProvider<UpsertDiscussionBloc>(
+                          create: (context) => UpsertDiscussionBloc(
+                              RepositoryProvider.of<DiscussionRepository>(
+                                  context))
+                            ..add(UpsertDiscussionMeUserChangeEvent(
+                                MeBloc.extractMe(
+                                    BlocProvider.of<MeBloc>(context).state)))
+                            ..add(UpsertDiscussionSelectDiscussionEvent(
+                                BlocProvider.of<DiscussionBloc>(context)
+                                    .state
+                                    .getDiscussion())),
+                          child: BlocListener<DiscussionBloc, DiscussionState>(
+                            listener: (context, state) {
+                              BlocProvider.of<UpsertDiscussionBloc>(context)
+                                  .add(UpsertDiscussionSelectDiscussionEvent(
+                                      state.getDiscussion()));
+                            },
+                            child: BlocListener<MeBloc, MeState>(
+                              listener: (context, state) {
+                                BlocProvider.of<UpsertDiscussionBloc>(context)
+                                    .add(UpsertDiscussionMeUserChangeEvent(
+                                        MeBloc.extractMe(state)));
+                              },
+                              child:
+                                  UpsertDiscussionScreen(arguments: arguments),
+                            ),
+                          ),
+                        ));
                     break;
                   case '/Auth':
                     return PageTransition(

--- a/lib/data/provider/mutations.dart
+++ b/lib/data/provider/mutations.dart
@@ -76,16 +76,18 @@ class JoinDiscussionWithVIPLinkMutation extends GQLMutation<Discussion> {
 
 class CreateDiscussionGQLMutation extends GQLMutation<Discussion> {
   final String title;
+  final String description;
   final AnonymityType anonymityType;
 
   const CreateDiscussionGQLMutation({
     @required this.title,
+    @required this.description,
     @required this.anonymityType,
   });
 
   final String _mutation = """
-    mutation CreateDiscussion(\$anonymityType: AnonymityType!, \$title: String!) {
-      createDiscussion(anonymityType: \$anonymityType, title: \$title) {
+    mutation CreateDiscussion(\$anonymityType: AnonymityType!, \$title: String!, \$description: String!) {
+      createDiscussion(anonymityType: \$anonymityType, title: \$title, description: \$description) {
         ...DiscussionFragmentFull
       }
     }
@@ -207,6 +209,7 @@ class ConciergeOptionMutation extends GQLMutation<Post> {
 class UpdateDiscussionMutation extends GQLMutation<Discussion> {
   final String discussionID;
   final String title;
+  final String description;
   final String iconURL;
 
   final String _mutation = """
@@ -221,12 +224,14 @@ class UpdateDiscussionMutation extends GQLMutation<Discussion> {
   const UpdateDiscussionMutation({
     @required this.discussionID,
     this.title,
+    this.description,
     this.iconURL,
   }) : super();
 
   Map<String, dynamic> createInputObject() {
     return {
       'title': this.title,
+      'description': this.description,
       'iconURL': this.iconURL,
     };
   }
@@ -354,7 +359,8 @@ class BanParticipantMutation extends GQLMutation<Participant> {
   }
 }
 
-class InviteTwitterUsersToDiscussionMutation extends GQLMutation<List<DiscussionInvite>> {
+class InviteTwitterUsersToDiscussionMutation
+    extends GQLMutation<List<DiscussionInvite>> {
   final String discussionID;
   final String invitingParticipantID;
   final List<TwitterUserInput> twitterUsers;
@@ -371,7 +377,7 @@ class InviteTwitterUsersToDiscussionMutation extends GQLMutation<List<Discussion
   const InviteTwitterUsersToDiscussionMutation({
     @required this.discussionID,
     @required this.invitingParticipantID,
-    @required this.twitterUsers
+    @required this.twitterUsers,
   }) : super();
 
   String mutation() {
@@ -384,4 +390,3 @@ class InviteTwitterUsersToDiscussionMutation extends GQLMutation<List<Discussion
         .toList();
   }
 }
-

--- a/lib/data/provider/mutations.dart
+++ b/lib/data/provider/mutations.dart
@@ -1,5 +1,6 @@
 import 'package:delphis_app/data/provider/queries.dart';
 import 'package:delphis_app/data/repository/discussion.dart';
+import 'package:delphis_app/data/repository/discussion_creation_settings.dart';
 import 'package:delphis_app/data/repository/discussion_invite.dart';
 import 'package:delphis_app/data/repository/flair.dart';
 import 'package:delphis_app/data/repository/participant.dart';
@@ -78,21 +79,31 @@ class CreateDiscussionGQLMutation extends GQLMutation<Discussion> {
   final String title;
   final String description;
   final AnonymityType anonymityType;
+  final DiscussionCreationSettings creationSettings;
 
   const CreateDiscussionGQLMutation({
     @required this.title,
     @required this.description,
     @required this.anonymityType,
+    @required this.creationSettings,
   });
 
   final String _mutation = """
-    mutation CreateDiscussion(\$anonymityType: AnonymityType!, \$title: String!, \$description: String!) {
-      createDiscussion(anonymityType: \$anonymityType, title: \$title, description: \$description) {
+    mutation CreateDiscussion(\$anonymityType: AnonymityType!, \$title: String!, \$description: String!, \$discussionSettings: DiscussionCreationSettings!) {
+      createDiscussion(anonymityType: \$anonymityType, title: \$title, description: \$description, discussionSettings : \$discussionSettings) {
         ...DiscussionFragmentFull
+        discussionLinksAccess {
+          ...DiscussionLinkAccessFragment
+        }
       }
     }
     $DiscussionFragmentFull
+    $DiscussionLinkAccessFragment
   """;
+
+  Map<String, dynamic> createInputObject() {
+    return this.creationSettings.toJSON();
+  }
 
   String mutation() {
     return this._mutation;

--- a/lib/data/provider/queries.dart
+++ b/lib/data/provider/queries.dart
@@ -264,6 +264,7 @@ const DiscussionListFragment = """
     }
     anonymityType
     iconURL
+    discussionJoinability
   }
   $DiscussionModeratorFragment
   $ParticipantInfoFragment

--- a/lib/data/provider/queries.dart
+++ b/lib/data/provider/queries.dart
@@ -249,6 +249,7 @@ const DiscussionListFragment = """
   fragment DiscussionListFragment on Discussion {
     id
     title
+    description
     moderator {
       ...DiscussionModeratorFragment
     }
@@ -273,6 +274,14 @@ const DiscussionFragmentFull = """
     ...DiscussionListFragment
     postsConnection {
       ...PostsConnectionFragment
+    }
+    titleHistory {
+      value
+      createdAt
+    }
+    descriptionHistory {
+      value
+      createdAt
     }
   }
   $DiscussionListFragment

--- a/lib/data/repository/discussion.dart
+++ b/lib/data/repository/discussion.dart
@@ -665,3 +665,8 @@ class DiscussionLinkAccess extends Equatable {
   factory DiscussionLinkAccess.fromJson(Map<String, dynamic> json) =>
       _$DiscussionLinkAccessFromJson(json);
 }
+
+enum DiscussionJoinabilitySetting {
+  ALLOW_TWITTER_FRIENDS,
+  ALL_REQUIRE_APPROVAL
+}

--- a/lib/data/repository/discussion.g.dart
+++ b/lib/data/repository/discussion.g.dart
@@ -48,6 +48,8 @@ Discussion _$DiscussionFromJson(Map<String, dynamic> json) {
             ? null
             : HistoricalString.fromJson(e as Map<String, dynamic>))
         ?.toList(),
+    discussionJoinability: _$enumDecodeNullable(
+        _$DiscussionJoinabilitySettingEnumMap, json['discussionJoinability']),
   );
 }
 
@@ -68,6 +70,8 @@ Map<String, dynamic> _$DiscussionToJson(Discussion instance) =>
       'description': instance.description,
       'titleHistory': instance.titleHistory,
       'descriptionHistory': instance.descriptionHistory,
+      'discussionJoinability':
+          _$DiscussionJoinabilitySettingEnumMap[instance.discussionJoinability],
     };
 
 T _$enumDecode<T>(
@@ -106,6 +110,11 @@ const _$AnonymityTypeEnumMap = {
   AnonymityType.UNKNOWN: 'UNKNOWN',
   AnonymityType.WEAK: 'WEAK',
   AnonymityType.STRONG: 'STRONG',
+};
+
+const _$DiscussionJoinabilitySettingEnumMap = {
+  DiscussionJoinabilitySetting.ALLOW_TWITTER_FRIENDS: 'ALLOW_TWITTER_FRIENDS',
+  DiscussionJoinabilitySetting.ALL_REQUIRE_APPROVAL: 'ALL_REQUIRE_APPROVAL',
 };
 
 DiscussionLinkAccess _$DiscussionLinkAccessFromJson(Map<String, dynamic> json) {

--- a/lib/data/repository/discussion.g.dart
+++ b/lib/data/repository/discussion.g.dart
@@ -37,6 +37,17 @@ Discussion _$DiscussionFromJson(Map<String, dynamic> json) {
         ? null
         : DiscussionLinkAccess.fromJson(
             json['discussionLinksAccess'] as Map<String, dynamic>),
+    description: json['description'] as String,
+    titleHistory: (json['titleHistory'] as List)
+        ?.map((e) => e == null
+            ? null
+            : HistoricalString.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+    descriptionHistory: (json['descriptionHistory'] as List)
+        ?.map((e) => e == null
+            ? null
+            : HistoricalString.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
   );
 }
 
@@ -54,6 +65,9 @@ Map<String, dynamic> _$DiscussionToJson(Discussion instance) =>
       'meAvailableParticipants': instance.meAvailableParticipants,
       'iconURL': instance.iconURL,
       'discussionLinksAccess': instance.discussionLinksAccess,
+      'description': instance.description,
+      'titleHistory': instance.titleHistory,
+      'descriptionHistory': instance.descriptionHistory,
     };
 
 T _$enumDecode<T>(

--- a/lib/data/repository/discussion_creation_settings.dart
+++ b/lib/data/repository/discussion_creation_settings.dart
@@ -1,0 +1,21 @@
+import 'package:delphis_app/data/repository/discussion.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'discussion_creation_settings.g.dart';
+
+@JsonSerializable()
+class DiscussionCreationSettings extends Equatable {
+  final DiscussionJoinabilitySetting discussionJoinability;
+
+  List<Object> get props => [
+        this.discussionJoinability,
+      ];
+
+  const DiscussionCreationSettings({@required this.discussionJoinability});
+
+  Map<String, dynamic> toJSON() {
+    return _$DiscussionCreationSettingsToJson(this);
+  }
+}

--- a/lib/data/repository/discussion_creation_settings.g.dart
+++ b/lib/data/repository/discussion_creation_settings.g.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'discussion_creation_settings.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+DiscussionCreationSettings _$DiscussionCreationSettingsFromJson(
+    Map<String, dynamic> json) {
+  return DiscussionCreationSettings(
+    discussionJoinability: _$enumDecodeNullable(
+        _$DiscussionJoinabilitySettingEnumMap, json['discussionJoinability']),
+  );
+}
+
+Map<String, dynamic> _$DiscussionCreationSettingsToJson(
+        DiscussionCreationSettings instance) =>
+    <String, dynamic>{
+      'discussionJoinability':
+          _$DiscussionJoinabilitySettingEnumMap[instance.discussionJoinability],
+    };
+
+T _$enumDecode<T>(
+  Map<T, dynamic> enumValues,
+  dynamic source, {
+  T unknownValue,
+}) {
+  if (source == null) {
+    throw ArgumentError('A value must be provided. Supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+
+  final value = enumValues.entries
+      .singleWhere((e) => e.value == source, orElse: () => null)
+      ?.key;
+
+  if (value == null && unknownValue == null) {
+    throw ArgumentError('`$source` is not one of the supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return value ?? unknownValue;
+}
+
+T _$enumDecodeNullable<T>(
+  Map<T, dynamic> enumValues,
+  dynamic source, {
+  T unknownValue,
+}) {
+  if (source == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source, unknownValue: unknownValue);
+}
+
+const _$DiscussionJoinabilitySettingEnumMap = {
+  DiscussionJoinabilitySetting.ALLOW_TWITTER_FRIENDS: 'ALLOW_TWITTER_FRIENDS',
+  DiscussionJoinabilitySetting.ALL_REQUIRE_APPROVAL: 'ALL_REQUIRE_APPROVAL',
+};

--- a/lib/data/repository/historical_string.dart
+++ b/lib/data/repository/historical_string.dart
@@ -1,0 +1,25 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'historical_string.g.dart';
+
+@JsonSerializable()
+class HistoricalString extends Equatable {
+  final String value;
+  final String createdAt;
+
+  HistoricalString({
+    this.value,
+    this.createdAt,
+  });
+
+  factory HistoricalString.fromJson(Map<String, dynamic> json) =>
+      _$HistoricalStringFromJson(json);
+
+  Map<String, dynamic> toJSON() {
+    return _$HistoricalStringToJson(this);
+  }
+
+  @override
+  List<Object> get props => [value, createdAt];
+}

--- a/lib/data/repository/historical_string.g.dart
+++ b/lib/data/repository/historical_string.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'historical_string.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+HistoricalString _$HistoricalStringFromJson(Map<String, dynamic> json) {
+  return HistoricalString(
+    value: json['value'] as String,
+    createdAt: json['createdAt'] as String,
+  );
+}
+
+Map<String, dynamic> _$HistoricalStringToJson(HistoricalString instance) =>
+    <String, dynamic>{
+      'value': instance.value,
+      'createdAt': instance.createdAt,
+    };

--- a/lib/design/colors.dart
+++ b/lib/design/colors.dart
@@ -84,12 +84,10 @@ class GradientStop {
 class ChathamColors {
   static final signInTwitterBackground = Color.fromRGBO(57, 58, 63, 1.0);
   static final twitterLogoColor = Color.fromRGBO(102, 196, 254, 1.0);
+  static final topBarBackgroundColor = Color.fromRGBO(22, 23, 28, 1.0);
 
   static final LinearGradient whiteGradient = LinearGradient(
-    colors: [
-      Colors.white,
-      Colors.white
-    ],
+    colors: [Colors.white, Colors.white],
   );
 
   static final LinearGradient notificationIconGradient = LinearGradient(

--- a/lib/screens/auth/base/sign_in.dart
+++ b/lib/screens/auth/base/sign_in.dart
@@ -1,7 +1,4 @@
-import 'dart:async';
-
 import 'package:delphis_app/bloc/auth/auth_bloc.dart';
-import 'package:delphis_app/constants.dart';
 import 'package:delphis_app/design/colors.dart';
 import 'package:delphis_app/design/sizes.dart';
 import 'package:delphis_app/design/text_theme.dart';
@@ -12,85 +9,35 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
-import 'package:uni_links/uni_links.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class SignInScreen extends StatefulWidget {
-  @override
-  _SignInScreenState createState() => _SignInScreenState();
-}
-
-class _SignInScreenState extends State<SignInScreen> {
+class SignInScreen extends StatelessWidget {
   static const twitterWidgetHeight = 76.0;
   static const feedbackLink =
       'mailto:ned@chatham.ai?subject=Twitter%20Makes%20Me%20Mad';
-  StreamSubscription _deepLinkSubscription;
-  AuthBloc authBloc;
-
-  @override
-  void dispose() {
-    _deepLinkSubscription?.cancel();
-    super.dispose();
-  }
-
-  @override
-  void initState() {
-    super.initState();
-
-    this.authBloc = BlocProvider.of<AuthBloc>(context);
-    this._deepLinkSubscription = getLinksStream().listen((String link) {
-      if (link.startsWith(Constants.twitterRedirectURLPrefix) ||
-          link.startsWith(Constants.twitterRedirectLegacyURLPrefix)) {
-        String token = RegExp("\\?dc=(.*)").firstMatch(link)?.group(1) ?? null;
-        if (token != null) {
-          this.authBloc.add(LoadedAuthEvent(token, true, false));
-        }
-      }
-    }, onError: (err) {
-      throw err;
-    });
-  }
-
-  void handleAppleLoginSuccessful(String accessToken) async {
-    this.authBloc.add(LoadedAuthEvent(accessToken, true, false));
-  }
-
-  void successfulLogin() async {
-    await closeWebView();
-    Navigator.of(context)
-        .pushNamedAndRemoveUntil('/Home', (Route<dynamic> route) => false);
-  }
-
-  void openLoginDialog() async {
-    var url = Constants.twitterLoginURL;
-    if (await canLaunch(url)) {
-      await launch(url);
-    } else {
-      throw 'Could not launch $url';
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      child: Scaffold(
-        resizeToAvoidBottomInset: true,
-        backgroundColor: Colors.black,
-        body: Container(
-          decoration: BoxDecoration(
-            color: Colors.black,
-          ),
-          alignment: Alignment.bottomCenter,
-          padding: EdgeInsets.symmetric(horizontal: SpacingValues.xxxxLarge),
-          child: LayoutBuilder(
-              builder: (BuildContext context, BoxConstraints constraints) {
-            return BlocListener<AuthBloc, AuthState>(
-              listener: (context, state) {
-                if (state is InitializedAuthState) {
-                  this.successfulLogin();
-                }
-              },
-              child: SizedBox(
+    return BlocListener<AuthBloc, AuthState>(
+      listener: (context, state) {
+        if (state is SignedInAuthState) {
+          Navigator.of(context).pushNamedAndRemoveUntil(
+              '/Home', (Route<dynamic> route) => false);
+        }
+      },
+      child: SafeArea(
+        child: Scaffold(
+          resizeToAvoidBottomInset: true,
+          backgroundColor: Colors.black,
+          body: Container(
+            decoration: BoxDecoration(
+              color: Colors.black,
+            ),
+            alignment: Alignment.bottomCenter,
+            padding: EdgeInsets.symmetric(horizontal: SpacingValues.xxxxLarge),
+            child: LayoutBuilder(
+                builder: (BuildContext context, BoxConstraints constraints) {
+              return SizedBox(
                 height: constraints.maxHeight * 0.7,
                 child: Flex(
                   direction: Axis.vertical,
@@ -120,14 +67,19 @@ class _SignInScreenState extends State<SignInScreen> {
                         Column(
                           children: [
                             LoginWithTwitterButton(
-                              onPressed: () => openLoginDialog(),
+                              onPressed: () {
+                                BlocProvider.of<AuthBloc>(context)
+                                    .add(TwitterSignInAuthEvent());
+                              },
                               width: constraints.maxWidth,
                               height: 56.0,
                             ),
                             SizedBox(height: SpacingValues.small),
                             SignInWithAppleButton(
-                              onLoginSuccessful:
-                                  this.handleAppleLoginSuccessful,
+                              onLoginSuccessful: (token) {
+                                BlocProvider.of<AuthBloc>(context)
+                                    .add(SetTokenAuthEvent(token));
+                              },
                             ),
                           ],
                         ),
@@ -154,9 +106,9 @@ class _SignInScreenState extends State<SignInScreen> {
                     ),
                   ],
                 ),
-              ),
-            );
-          }),
+              );
+            }),
+          ),
         ),
       ),
     );

--- a/lib/screens/auth/base/sign_in.dart
+++ b/lib/screens/auth/base/sign_in.dart
@@ -4,6 +4,7 @@ import 'package:delphis_app/design/sizes.dart';
 import 'package:delphis_app/design/text_theme.dart';
 import 'package:delphis_app/screens/auth/base/widgets/apple_signin.dart';
 import 'package:delphis_app/screens/auth/base/widgets/loginWithTwitterButton/twitter_button.dart';
+import 'package:delphis_app/widgets/animated_size_container/animated_size_container.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -66,6 +67,39 @@ class SignInScreen extends StatelessWidget {
                         SizedBox(height: SpacingValues.mediumLarge),
                         Column(
                           children: [
+                            AnimatedSizeContainer(
+                              builder: (context) {
+                                return BlocBuilder<AuthBloc, AuthState>(
+                                  builder: (context, state) {
+                                    if (state is LoadingAuthState) {
+                                      return Container(
+                                        margin: EdgeInsets.only(
+                                            bottom: SpacingValues.large),
+                                        child: Center(
+                                          child: CircularProgressIndicator(),
+                                        ),
+                                      );
+                                    } else if (state is ErrorAuthState) {
+                                      return Container(
+                                        margin: EdgeInsets.only(
+                                            bottom: SpacingValues.large),
+                                        child: Center(
+                                          child: Text(
+                                            state.error.toString(),
+                                            textAlign: TextAlign.center,
+                                            style: TextThemes.discussionPostText
+                                                .copyWith(
+                                              color: Colors.red,
+                                            ),
+                                          ),
+                                        ),
+                                      );
+                                    }
+                                    return Container();
+                                  },
+                                );
+                              },
+                            ),
                             LoginWithTwitterButton(
                               onPressed: () {
                                 BlocProvider.of<AuthBloc>(context)

--- a/lib/screens/auth/base/widgets/loginWithTwitterButton/twitter_button.dart
+++ b/lib/screens/auth/base/widgets/loginWithTwitterButton/twitter_button.dart
@@ -21,36 +21,40 @@ class LoginWithTwitterButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final borderRadius = BorderRadius.circular(this.height / 2.0);
     return Pressable(
-        width: this.width,
-        height: this.height,
-        onPressed: this.onPressed,
+      width: this.width,
+      height: this.height,
+      onPressed: this.onPressed,
+      decoration: BoxDecoration(
+        shape: BoxShape.rectangle,
+        borderRadius: borderRadius,
+      ),
+      child: Container(
+        height: height,
+        width: width,
         decoration: BoxDecoration(
           shape: BoxShape.rectangle,
+          color: Color.fromRGBO(247, 247, 255, 1.0),
           borderRadius: borderRadius,
         ),
-        child: Container(
-            decoration: BoxDecoration(
-              shape: BoxShape.rectangle,
-              color: Color.fromRGBO(247, 247, 255, 1.0),
-              borderRadius: borderRadius,
+        alignment: Alignment.center,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            SvgPicture.asset(
+              'assets/svg/twitter_logo.svg',
+              color: ChathamColors.twitterLogoColor,
+              semanticsLabel: 'Twitter Logo',
+              width: 28.0,
+              height: 23.0,
             ),
-            alignment: Alignment.center,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                SvgPicture.asset(
-                  'assets/svg/twitter_logo.svg',
-                  color: ChathamColors.twitterLogoColor,
-                  semanticsLabel: 'Twitter Logo',
-                  width: 28.0,
-                  height: 23.0,
-                ),
-                SizedBox(width: SpacingValues.small),
-                Text(
-                  Intl.message('Sign in with Twitter'),
-                  style: TextThemes.signInWithTwitter,
-                ),
-              ],
-            )));
+            SizedBox(width: SpacingValues.small),
+            Text(
+              Intl.message('Sign in with Twitter'),
+              style: TextThemes.signInWithTwitter,
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/screens/home_page/chats/chats_list.dart
+++ b/lib/screens/home_page/chats/chats_list.dart
@@ -127,7 +127,7 @@ class ChatsList extends StatelessWidget {
                   }
                   return SingleChat(
                     discussion: discussionElem,
-                    canJoinDiscussions: currentUser?.isTwitterAuth,
+                    canJoinDiscussions: currentUser?.isTwitterAuth ?? false,
                     onJoinPressed: () {
                       this.onJoinDiscussionPressed(discussionElem);
                     },

--- a/lib/screens/home_page/chats/chats_list.dart
+++ b/lib/screens/home_page/chats/chats_list.dart
@@ -127,7 +127,7 @@ class ChatsList extends StatelessWidget {
                   }
                   return SingleChat(
                     discussion: discussionElem,
-                    canJoinDiscussions: currentUser.isTwitterAuth,
+                    canJoinDiscussions: currentUser?.isTwitterAuth,
                     onJoinPressed: () {
                       this.onJoinDiscussionPressed(discussionElem);
                     },

--- a/lib/screens/home_page/home_page.dart
+++ b/lib/screens/home_page/home_page.dart
@@ -95,40 +95,10 @@ class _HomePageScreenState extends State<HomePageScreen> {
       },
     );
 
-    return BlocListener<DiscussionBloc, DiscussionState>(
-        listenWhen: (prev, next) {
-      return prev is AddingDiscussionState &&
-          next is DiscussionLoadedState &&
-          !next.isLoading;
-    }, listener: (context, state) {
-      if (state is DiscussionLoadedState && !state.isLoading) {
-        Navigator.of(context).pushNamed(
-          '/Discussion',
-          arguments: DiscussionArguments(
-            discussionID: state.getDiscussion().id,
-            isStartJoinFlow: false,
-          ),
-        );
-      }
-    }, child: BlocBuilder<DiscussionBloc, DiscussionState>(
-      builder: (context, state) {
-        if (state is AddingDiscussionState) {
-          return AbsorbPointer(
-            absorbing: true,
-            child: Stack(
-              children: [
-                Opacity(opacity: 0.4, child: content),
-                Center(child: CircularProgressIndicator()),
-              ],
-            ),
-          );
-        }
-        return Scaffold(
-          resizeToAvoidBottomInset: true,
-          backgroundColor: backgroundColor,
-          body: content,
-        );
-      },
-    ));
+    return Scaffold(
+      resizeToAvoidBottomInset: true,
+      backgroundColor: backgroundColor,
+      body: content,
+    );
   }
 }

--- a/lib/screens/home_page/home_page.dart
+++ b/lib/screens/home_page/home_page.dart
@@ -1,9 +1,11 @@
 import 'package:delphis_app/bloc/discussion/discussion_bloc.dart';
 import 'package:delphis_app/bloc/me/me_bloc.dart';
 import 'package:delphis_app/data/repository/discussion.dart';
+import 'package:delphis_app/design/colors.dart';
 import 'package:delphis_app/screens/discussion/screen_args/discussion.dart';
 import 'package:delphis_app/screens/home_page/chats/chats_screen.dart';
 import 'package:delphis_app/screens/home_page/home_page_topbar.dart';
+import 'package:delphis_app/screens/upsert_discussion/screen_arguments.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
@@ -34,7 +36,6 @@ class HomePageScreen extends StatefulWidget {
 }
 
 class _HomePageScreenState extends State<HomePageScreen> {
-  final Color _topBarBackgroundColor = Color.fromRGBO(22, 23, 28, 1.0);
   HomePageTab _currentTab;
 
   @override
@@ -66,11 +67,11 @@ class _HomePageScreenState extends State<HomePageScreen> {
             children: [
               Container(
                   height: windowPadding.top,
-                  color: this._topBarBackgroundColor),
+                  color: ChathamColors.topBarBackgroundColor),
               HomePageTopBar(
                   height: 80.0,
                   title: Intl.message('Chats'),
-                  backgroundColor: this._topBarBackgroundColor),
+                  backgroundColor: ChathamColors.topBarBackgroundColor),
               Expanded(
                 child: ChatsScreen(
                   discussionRepository: this.widget.discussionRepository,
@@ -82,16 +83,10 @@ class _HomePageScreenState extends State<HomePageScreen> {
                   ? Container(width: 0, height: 0)
                   : HomePageActionBar(
                       currentTab: this._currentTab,
-                      backgroundColor: this._topBarBackgroundColor,
+                      backgroundColor: ChathamColors.topBarBackgroundColor,
                       onNewChatPressed: () {
-                        BlocProvider.of<DiscussionBloc>(context).add(
-                          NewDiscussionEvent(
-                            title:
-                                "${currentUser.profile.displayName}'s discussion",
-                            anonymityType: AnonymityType.UNKNOWN,
-                            nonce: DateTime.now().toString(),
-                          ),
-                        );
+                        Navigator.pushNamed(context, '/Discussion/Upsert',
+                            arguments: UpsertDiscussionArguments());
                       },
                     ),
             ],

--- a/lib/screens/intro/intro_screen.dart
+++ b/lib/screens/intro/intro_screen.dart
@@ -14,37 +14,28 @@ class IntroScreen extends StatelessWidget {
   FutureOr<bool> _navigateIfReady(BuildContext context,
       GqlClientState clientState, AuthState authState) async {
     if (clientState is GqlClientConnectedState) {
-      if (authState is InitializedAuthState && authState.isAuthed) {
+      if (authState is SignedInAuthState) {
         var loadedHome = false;
         try {
-          var lastRoute = await chathamRouteObserverSingleton.retrieveLastRouteName();
-          var lastArgs = await chathamRouteObserverSingleton.retriveLastRouteArguments();
+          var lastRoute =
+              await chathamRouteObserverSingleton.retrieveLastRouteName();
+          var lastArgs =
+              await chathamRouteObserverSingleton.retriveLastRouteArguments();
           Navigator.pushNamedAndRemoveUntil(
-            context,
-            '/Home',
-            (Route<dynamic> route) => false
-          );
+              context, '/Home', (Route<dynamic> route) => false);
           loadedHome = true;
-          Navigator.pushNamed(
-            context,
-            lastRoute,
-            arguments: lastArgs
-          );
-        }
-        catch (error) {
+          Navigator.pushNamed(context, lastRoute, arguments: lastArgs);
+        } catch (error) {
           /* Probably something is broken in the local storage,
              or simply there is no screen history saved.
              In this case we just load the default home page. */
-          if(!loadedHome) {
+          if (!loadedHome) {
             Navigator.pushNamedAndRemoveUntil(
-              context,
-              '/Home',
-              (Route<dynamic> route) => false
-            );
+                context, '/Home', (Route<dynamic> route) => false);
           }
         }
         return true;
-      } else if (authState is InitializedAuthState) {
+      } else if (authState is LoggedOutAuthState) {
         Navigator.pushNamedAndRemoveUntil(
             context, '/Auth', (Route<dynamic> route) => false);
         return true;
@@ -67,22 +58,25 @@ class IntroScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     Segment.track(eventName: ChathamTrackingEventNames.APP_INITIALIZED);
-    return BlocListener<GqlClientBloc, GqlClientState>(
-      listener: (context, state) {
-        if (state is GqlClientConnectedState) {
-          this._navigateWhenReady(
-              context, state, BlocProvider.of<AuthBloc>(context).state);
-        }
-      },
-      child: Container(
-        color: Colors.black,
-        child: Center(
-          child: Image.asset(
-            'assets/images/app_icon/image.png',
-            width: 60.0,
+    return BlocBuilder<AuthBloc, AuthState>(
+      builder: (context, authState) {
+        return BlocListener<GqlClientBloc, GqlClientState>(
+          listener: (context, gqlState) {
+            if (gqlState is GqlClientConnectedState) {
+              this._navigateWhenReady(context, gqlState, authState);
+            }
+          },
+          child: Container(
+            color: Colors.black,
+            child: Center(
+              child: Image.asset(
+                'assets/images/app_icon/image.png',
+                width: 60.0,
+              ),
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/screens/upsert_discussion/pages/base_page_widget.dart
+++ b/lib/screens/upsert_discussion/pages/base_page_widget.dart
@@ -1,6 +1,5 @@
 import 'package:delphis_app/design/colors.dart';
 import 'package:delphis_app/design/sizes.dart';
-import 'package:delphis_app/design/text_theme.dart';
 import 'package:delphis_app/screens/home_page/home_page_topbar.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';

--- a/lib/screens/upsert_discussion/pages/base_page_widget.dart
+++ b/lib/screens/upsert_discussion/pages/base_page_widget.dart
@@ -1,0 +1,78 @@
+import 'package:delphis_app/design/colors.dart';
+import 'package:delphis_app/design/sizes.dart';
+import 'package:delphis_app/design/text_theme.dart';
+import 'package:delphis_app/screens/home_page/home_page_topbar.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class BasePageWidget extends StatelessWidget {
+  final Widget contents;
+  final String title;
+  final String backButtonText;
+  final String nextButtonText;
+  final VoidCallback onNext;
+  final VoidCallback onBack;
+
+  const BasePageWidget({
+    @required this.contents,
+    @required this.title,
+    @required this.backButtonText,
+    @required this.nextButtonText,
+    @required this.onNext,
+    @required this.onBack,
+  }) : super();
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Container(
+        padding: EdgeInsets.only(bottom: SpacingValues.large),
+        child: Column(
+          children: [
+            Container(
+              color: ChathamColors.topBarBackgroundColor,
+            ),
+            HomePageTopBar(
+              height: 80.0,
+              title: Intl.message(title),
+              backgroundColor: ChathamColors.topBarBackgroundColor,
+            ),
+            this.contents,
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                RaisedButton(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: SpacingValues.large,
+                    vertical: SpacingValues.medium,
+                  ),
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(25.0)),
+                  color: Color.fromRGBO(247, 247, 255, 0.2),
+                  child: Text(this.backButtonText),
+                  onPressed: this.onBack,
+                ),
+                RaisedButton(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: SpacingValues.xxLarge,
+                    vertical: SpacingValues.medium,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(25.0),
+                  ),
+                  color: Color.fromRGBO(247, 247, 255, 1.0),
+                  child: Text(
+                    Intl.message(this.nextButtonText),
+                    style: TextThemes.joinButtonTextChatTab,
+                  ),
+                  onPressed: this.onNext,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/upsert_discussion/pages/base_page_widget.dart
+++ b/lib/screens/upsert_discussion/pages/base_page_widget.dart
@@ -8,18 +8,26 @@ import 'package:intl/intl.dart';
 class BasePageWidget extends StatelessWidget {
   final Widget contents;
   final String title;
-  final String backButtonText;
-  final String nextButtonText;
+  final Widget backButtonChild;
+  final Widget nextButtonChild;
+  final bool backDisable;
+  final bool nextDisable;
+  final Color backColor;
+  final Color nextColor;
   final VoidCallback onNext;
   final VoidCallback onBack;
 
   const BasePageWidget({
     @required this.contents,
     @required this.title,
-    @required this.backButtonText,
-    @required this.nextButtonText,
-    @required this.onNext,
-    @required this.onBack,
+    this.backButtonChild,
+    this.nextButtonChild,
+    this.onNext,
+    this.onBack,
+    this.backDisable = false,
+    this.nextDisable = false,
+    this.backColor,
+    this.nextColor,
   }) : super();
 
   @override
@@ -42,32 +50,38 @@ class BasePageWidget extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceAround,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                RaisedButton(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: SpacingValues.large,
-                    vertical: SpacingValues.medium,
-                  ),
-                  shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(25.0)),
-                  color: Color.fromRGBO(247, 247, 255, 0.2),
-                  child: Text(this.backButtonText),
-                  onPressed: this.onBack,
-                ),
-                RaisedButton(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: SpacingValues.xxLarge,
-                    vertical: SpacingValues.medium,
-                  ),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(25.0),
-                  ),
-                  color: Color.fromRGBO(247, 247, 255, 1.0),
-                  child: Text(
-                    Intl.message(this.nextButtonText),
-                    style: TextThemes.joinButtonTextChatTab,
-                  ),
-                  onPressed: this.onNext,
-                ),
+                this.backDisable
+                    ? Container()
+                    : RaisedButton(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: SpacingValues.large,
+                          vertical: SpacingValues.medium,
+                        ),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(25.0)),
+                        color: this.backColor ??
+                            Color.fromRGBO(247, 247, 255, 0.2),
+                        child: this.backButtonChild,
+                        onPressed: this.onBack,
+                        animationDuration: Duration(milliseconds: 100),
+                      ),
+                this.nextDisable
+                    ? Container()
+                    : RaisedButton(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: SpacingValues.xxLarge,
+                          vertical: SpacingValues.medium,
+                        ),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(25.0),
+                        ),
+                        color: this.nextColor ??
+                            Color.fromRGBO(247, 247, 255, 1.0),
+                        child: this.nextButtonChild,
+                        onPressed: this.onNext,
+                        splashColor: Colors.grey.withOpacity(0.8),
+                        animationDuration: Duration(milliseconds: 100),
+                      ),
               ],
             ),
           ],

--- a/lib/screens/upsert_discussion/pages/confirmation_page.dart
+++ b/lib/screens/upsert_discussion/pages/confirmation_page.dart
@@ -1,3 +1,4 @@
+import 'package:delphis_app/bloc/discussion/discussion_bloc.dart';
 import 'package:delphis_app/bloc/notification/notification_bloc.dart';
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_info.dart';
@@ -69,7 +70,9 @@ class ConfirmationPage extends StatelessWidget {
                     ],
                   ),
                   backDisable: true,
-                  onNext: this.onNext,
+                  onNext: this.onNext == null
+                      ? null
+                      : () => this.onNextInternal(context, state.info),
                   contents: Expanded(
                     child: Container(
                       color: Colors.transparent,
@@ -310,5 +313,13 @@ class ConfirmationPage extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  void onNextInternal(BuildContext context, UpsertDiscussionInfo info) {
+    if (this.onNext != null) {
+      BlocProvider.of<DiscussionBloc>(context)
+          .add(LoadLocalDiscussionEvent(discussion: info.discussion));
+      this.onNext();
+    }
   }
 }

--- a/lib/screens/upsert_discussion/pages/confirmation_page.dart
+++ b/lib/screens/upsert_discussion/pages/confirmation_page.dart
@@ -1,0 +1,409 @@
+import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
+import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_info.dart';
+import 'package:delphis_app/design/colors.dart';
+import 'package:delphis_app/design/sizes.dart';
+import 'package:delphis_app/design/text_theme.dart';
+import 'package:delphis_app/screens/upsert_discussion/pages/base_page_widget.dart';
+import 'package:delphis_app/screens/upsert_discussion/pages/invite_mode_page.dart';
+import 'package:delphis_app/widgets/animated_size_container/animated_size_container.dart';
+import 'package:delphis_app/widgets/pressable/pressable.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:intl/intl.dart';
+
+class ConfirmationPage extends StatelessWidget {
+  final String nextButtonText;
+  final String prevButtonText;
+  final VoidCallback onBack;
+  final VoidCallback onNext;
+  final VoidCallback onRetry;
+
+  const ConfirmationPage({
+    Key key,
+    @required this.nextButtonText,
+    @required this.prevButtonText,
+    @required this.onBack,
+    @required this.onNext,
+    @required this.onRetry,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<UpsertDiscussionBloc, UpsertDiscussionState>(
+      builder: (context, state) {
+        if (state is UpsertDiscussionLoadingState ||
+            state is UpsertDiscussionErrorState) {
+          return buildDuringCreation(context, state);
+        } else if (state is UpsertDiscussionReadyState) {
+          return buildConfirmation(context, state.info);
+        }
+        return Container();
+      },
+    );
+  }
+
+  Widget buildDuringCreation(
+      BuildContext context, UpsertDiscussionState state) {
+    final height = MediaQuery.of(context).size.height;
+    String title = Intl.message("Loading...");
+    if (state is UpsertDiscussionErrorState) {
+      title = Intl.message("Uh oh!");
+    }
+    Widget content = Container();
+    if (state is UpsertDiscussionLoadingState) {
+      content = Container(
+        child: Center(
+          child: Column(
+            children: <Widget>[
+              Text(
+                Intl.message(
+                    "We are creating your new discussion, please hold on a little longer..."),
+                style: TextThemes.onboardBody,
+                textAlign: TextAlign.center,
+              ),
+              SizedBox(height: SpacingValues.large),
+              CircularProgressIndicator()
+            ],
+          ),
+        ),
+      );
+    } else if (state is UpsertDiscussionErrorState) {
+      content = Container(
+        child: Center(
+          child: Column(
+            children: <Widget>[
+              Text(
+                state.error.toString(),
+                textAlign: TextAlign.center,
+                style: TextThemes.onboardBody.copyWith(
+                  color: Colors.red,
+                ),
+              ),
+              SizedBox(height: SpacingValues.large),
+              Pressable(
+                height: 50,
+                width: double.infinity,
+                onPressed: this.onRetry,
+                decoration: BoxDecoration(
+                  shape: BoxShape.rectangle,
+                  borderRadius: BorderRadius.circular(100.0),
+                ),
+                child: Container(
+                  decoration: BoxDecoration(
+                    shape: BoxShape.rectangle,
+                    color: Color.fromRGBO(247, 247, 255, 1.0),
+                    borderRadius: BorderRadius.circular(100.0),
+                  ),
+                  alignment: Alignment.center,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        Intl.message('Try again'),
+                        style: TextThemes.signInWithTwitter,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              SizedBox(height: SpacingValues.small),
+              RaisedButton(
+                padding: EdgeInsets.symmetric(
+                  horizontal: SpacingValues.xxxxLarge,
+                  vertical: SpacingValues.medium,
+                ),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(25.0)),
+                color: Color.fromRGBO(247, 247, 255, 0.2),
+                child: Text(Intl.message("Go back")),
+                onPressed: this.onBack,
+                animationDuration: Duration(milliseconds: 100),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: Container(
+          height: height,
+          decoration: BoxDecoration(
+            color: Colors.black,
+          ),
+          child: BasePageWidget(
+            title: title,
+            backDisable: true,
+            nextDisable: true,
+            contents: Expanded(
+              child: Container(
+                margin: EdgeInsets.all(SpacingValues.extraLarge),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Image.asset(
+                      'assets/images/app_icon/image.png',
+                      width: 96.0,
+                      height: 96.0,
+                    ),
+                    SizedBox(height: SpacingValues.large),
+                    AnimatedSizeContainer(
+                      builder: (context) {
+                        return content;
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget buildConfirmation(BuildContext context, UpsertDiscussionInfo info) {
+    final height = MediaQuery.of(context).size.height;
+    String inviteMode = '';
+    switch (info.inviteMode) {
+      case DiscussionInviteMode.EVERYONE_FOLLOWED:
+        inviteMode = InviteModePage.everyoneFollowedText;
+        break;
+      case DiscussionInviteMode.EVERYONE_APPROVED:
+        inviteMode = InviteModePage.everyoneApprovedText;
+        break;
+    }
+    return Scaffold(
+      resizeToAvoidBottomInset: true,
+      body: SingleChildScrollView(
+        child: Container(
+          color: Colors.black,
+          height: height,
+          child: BasePageWidget(
+            title: "Congratulations!",
+            nextButtonChild: Row(
+              children: <Widget>[
+                Text(
+                  this.nextButtonText,
+                  style: TextThemes.joinButtonTextChatTab,
+                ),
+                SizedBox(
+                  width: SpacingValues.small,
+                ),
+                Icon(Icons.arrow_forward, color: Colors.black),
+              ],
+            ),
+            backDisable: true,
+            onNext: this.onNext,
+            contents: Expanded(
+              child: Container(
+                color: Colors.transparent,
+                padding: EdgeInsets.all(SpacingValues.extraLarge),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    Container(
+                      child: SvgPicture.asset(
+                        'assets/svg/chat-icon.svg',
+                        width: 80,
+                        color: Colors.white,
+                      ),
+                    ),
+                    SizedBox(
+                      height: SpacingValues.xxLarge,
+                    ),
+                    Text(
+                      Intl.message(
+                          'Your new discussion has been successfully created.'),
+                      style: TextThemes.onboardHeading,
+                      textAlign: TextAlign.center,
+                    ),
+                    SizedBox(
+                      height: SpacingValues.mediumLarge,
+                    ),
+                    Container(
+                      margin:
+                          EdgeInsets.symmetric(horizontal: SpacingValues.large),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.start,
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: <Widget>[
+                                _BulletPoint(
+                                  color: Colors.white,
+                                  size: TextThemes.onboardBody.fontSize / 1.5,
+                                ),
+                                SizedBox(width: SpacingValues.large),
+                                Flexible(
+                                  child: Column(
+                                    mainAxisAlignment: MainAxisAlignment.start,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: <Widget>[
+                                      Text(
+                                        info.title,
+                                        style: TextThemes.onboardBody.copyWith(
+                                            fontWeight: FontWeight.bold),
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                      SizedBox(
+                                        height: SpacingValues.small,
+                                      ),
+                                      Text(
+                                        info.description,
+                                        maxLines: 2,
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                    ],
+                                  ),
+                                )
+                              ],
+                            ),
+                          ),
+                          SizedBox(
+                            height: SpacingValues.medium,
+                          ),
+                          Container(
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.start,
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: <Widget>[
+                                _BulletPoint(
+                                  color: Colors.white,
+                                  size: TextThemes.onboardBody.fontSize / 1.5,
+                                ),
+                                SizedBox(width: SpacingValues.large),
+                                Flexible(
+                                  child: Text(
+                                    inviteMode,
+                                    style: TextThemes.onboardBody,
+                                    maxLines: 4,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                )
+                              ],
+                            ),
+                          )
+                        ],
+                      ),
+                    ),
+                    SizedBox(
+                      height: SpacingValues.large,
+                    ),
+                    Pressable(
+                      height: 50,
+                      width: double.infinity,
+                      onPressed: () => copyInvitationLink(context, info),
+                      decoration: BoxDecoration(
+                        shape: BoxShape.rectangle,
+                        borderRadius: BorderRadius.circular(100.0),
+                      ),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          shape: BoxShape.rectangle,
+                          color: Color.fromRGBO(247, 247, 255, 1.0),
+                          borderRadius: BorderRadius.circular(100.0),
+                        ),
+                        alignment: Alignment.center,
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              Icons.content_copy,
+                              color: Colors.black,
+                              size: 30,
+                            ),
+                            SizedBox(
+                              width: SpacingValues.smallMedium,
+                            ),
+                            Text(
+                              Intl.message('Copy invitation link'),
+                              style: TextThemes.signInWithTwitter,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    SizedBox(
+                      height: SpacingValues.mediumLarge,
+                    ),
+                    Pressable(
+                      height: 50,
+                      width: double.infinity,
+                      onPressed: () => sendInvitationTweet(context, info),
+                      decoration: BoxDecoration(
+                        shape: BoxShape.rectangle,
+                        borderRadius: BorderRadius.circular(100.0),
+                      ),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          shape: BoxShape.rectangle,
+                          color: ChathamColors.twitterLogoColor,
+                          borderRadius: BorderRadius.circular(100.0),
+                        ),
+                        alignment: Alignment.center,
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            SvgPicture.asset(
+                              'assets/svg/twitter_logo.svg',
+                              color: Colors.black,
+                              width: 32.0,
+                              height: 32.0,
+                            ),
+                            SizedBox(
+                              width: SpacingValues.smallMedium,
+                            ),
+                            Text(
+                              Intl.message('Tweet your invite'),
+                              style: TextThemes.signInWithTwitter,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void sendInvitationTweet(BuildContext context, UpsertDiscussionInfo info) {
+    // TODO: Sent real tweet
+  }
+
+  void copyInvitationLink(BuildContext context, UpsertDiscussionInfo info) {
+    // TODO: Copy to clipboard and send notification to user
+  }
+}
+
+class _BulletPoint extends StatelessWidget {
+  final Color color;
+  final double size;
+
+  const _BulletPoint({Key key, @required this.color, @required this.size})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.only(top: size * 0.3),
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+      ),
+    );
+  }
+}

--- a/lib/screens/upsert_discussion/pages/confirmation_page.dart
+++ b/lib/screens/upsert_discussion/pages/confirmation_page.dart
@@ -286,7 +286,7 @@ class ConfirmationPage extends StatelessWidget {
       BuildContext context, UpsertDiscussionInfo info) async {
     String url = Uri.https("twitter.com", "/intent/tweet", {
       "text": Intl.message(
-          "I’m moderating a discussion: “${info.title}”.\n\nJoin:"),
+          "Check out my discussion “${info.title}” on @chathamai:"),
       "url": info.inviteLink
     }).toString();
     if (await canLaunch(url)) {

--- a/lib/screens/upsert_discussion/pages/confirmation_page.dart
+++ b/lib/screens/upsert_discussion/pages/confirmation_page.dart
@@ -1,10 +1,12 @@
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_info.dart';
+import 'package:delphis_app/data/repository/discussion.dart';
 import 'package:delphis_app/design/colors.dart';
 import 'package:delphis_app/design/sizes.dart';
 import 'package:delphis_app/design/text_theme.dart';
 import 'package:delphis_app/screens/upsert_discussion/pages/base_page_widget.dart';
 import 'package:delphis_app/screens/upsert_discussion/pages/invite_mode_page.dart';
+import 'package:delphis_app/screens/upsert_discussion/widgets/bullet_point.dart';
 import 'package:delphis_app/widgets/animated_size_container/animated_size_container.dart';
 import 'package:delphis_app/widgets/pressable/pressable.dart';
 import 'package:flutter/cupertino.dart';
@@ -18,7 +20,6 @@ class ConfirmationPage extends StatelessWidget {
   final String prevButtonText;
   final VoidCallback onBack;
   final VoidCallback onNext;
-  final VoidCallback onRetry;
 
   const ConfirmationPage({
     Key key,
@@ -26,240 +27,157 @@ class ConfirmationPage extends StatelessWidget {
     @required this.prevButtonText,
     @required this.onBack,
     @required this.onNext,
-    @required this.onRetry,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<UpsertDiscussionBloc, UpsertDiscussionState>(
       builder: (context, state) {
-        if (state is UpsertDiscussionLoadingState ||
-            state is UpsertDiscussionErrorState) {
-          return buildDuringCreation(context, state);
-        } else if (state is UpsertDiscussionReadyState) {
-          return buildConfirmation(context, state.info);
-        }
-        return Container();
-      },
-    );
-  }
-
-  Widget buildDuringCreation(
-      BuildContext context, UpsertDiscussionState state) {
-    final height = MediaQuery.of(context).size.height;
-    String title = Intl.message("Loading...");
-    if (state is UpsertDiscussionErrorState) {
-      title = Intl.message("Uh oh!");
-    }
-    Widget content = Container();
-    if (state is UpsertDiscussionLoadingState) {
-      content = Container(
-        child: Center(
-          child: Column(
-            children: <Widget>[
-              Text(
-                Intl.message(
-                    "We are creating your new discussion, please hold on a little longer..."),
-                style: TextThemes.onboardBody,
-                textAlign: TextAlign.center,
-              ),
-              SizedBox(height: SpacingValues.large),
-              CircularProgressIndicator()
-            ],
-          ),
-        ),
-      );
-    } else if (state is UpsertDiscussionErrorState) {
-      content = Container(
-        child: Center(
-          child: Column(
-            children: <Widget>[
-              Text(
-                state.error.toString(),
-                textAlign: TextAlign.center,
-                style: TextThemes.onboardBody.copyWith(
-                  color: Colors.red,
-                ),
-              ),
-              SizedBox(height: SpacingValues.large),
-              Pressable(
-                height: 50,
-                width: double.infinity,
-                onPressed: this.onRetry,
-                decoration: BoxDecoration(
-                  shape: BoxShape.rectangle,
-                  borderRadius: BorderRadius.circular(100.0),
-                ),
-                child: Container(
-                  decoration: BoxDecoration(
-                    shape: BoxShape.rectangle,
-                    color: Color.fromRGBO(247, 247, 255, 1.0),
-                    borderRadius: BorderRadius.circular(100.0),
-                  ),
-                  alignment: Alignment.center,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
+        if (state is UpsertDiscussionReadyState) {
+          final height = MediaQuery.of(context).size.height;
+          String inviteMode = '';
+          switch (state.info.inviteMode) {
+            case DiscussionJoinabilitySetting.ALLOW_TWITTER_FRIENDS:
+              inviteMode = InviteModePage.allowTwitterFriendsText;
+              break;
+            case DiscussionJoinabilitySetting.ALL_REQUIRE_APPROVAL:
+              inviteMode = InviteModePage.allRequireApprovalText;
+              break;
+          }
+          return Scaffold(
+            resizeToAvoidBottomInset: true,
+            body: SingleChildScrollView(
+              child: Container(
+                color: Colors.black,
+                height: height,
+                child: BasePageWidget(
+                  title: "Congratulations!",
+                  nextButtonChild: Row(
+                    children: <Widget>[
                       Text(
-                        Intl.message('Try again'),
-                        style: TextThemes.signInWithTwitter,
+                        this.nextButtonText,
+                        style: TextThemes.joinButtonTextChatTab,
                       ),
+                      SizedBox(
+                        width: SpacingValues.small,
+                      ),
+                      Icon(Icons.arrow_forward, color: Colors.black),
                     ],
                   ),
-                ),
-              ),
-              SizedBox(height: SpacingValues.small),
-              RaisedButton(
-                padding: EdgeInsets.symmetric(
-                  horizontal: SpacingValues.xxxxLarge,
-                  vertical: SpacingValues.medium,
-                ),
-                shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(25.0)),
-                color: Color.fromRGBO(247, 247, 255, 0.2),
-                child: Text(Intl.message("Go back")),
-                onPressed: this.onBack,
-                animationDuration: Duration(milliseconds: 100),
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-    return Scaffold(
-      body: SingleChildScrollView(
-        child: Container(
-          height: height,
-          decoration: BoxDecoration(
-            color: Colors.black,
-          ),
-          child: BasePageWidget(
-            title: title,
-            backDisable: true,
-            nextDisable: true,
-            contents: Expanded(
-              child: Container(
-                margin: EdgeInsets.all(SpacingValues.extraLarge),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Image.asset(
-                      'assets/images/app_icon/image.png',
-                      width: 96.0,
-                      height: 96.0,
-                    ),
-                    SizedBox(height: SpacingValues.large),
-                    AnimatedSizeContainer(
-                      builder: (context) {
-                        return content;
-                      },
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget buildConfirmation(BuildContext context, UpsertDiscussionInfo info) {
-    final height = MediaQuery.of(context).size.height;
-    String inviteMode = '';
-    switch (info.inviteMode) {
-      case DiscussionInviteMode.EVERYONE_FOLLOWED:
-        inviteMode = InviteModePage.everyoneFollowedText;
-        break;
-      case DiscussionInviteMode.EVERYONE_APPROVED:
-        inviteMode = InviteModePage.everyoneApprovedText;
-        break;
-    }
-    return Scaffold(
-      resizeToAvoidBottomInset: true,
-      body: SingleChildScrollView(
-        child: Container(
-          color: Colors.black,
-          height: height,
-          child: BasePageWidget(
-            title: "Congratulations!",
-            nextButtonChild: Row(
-              children: <Widget>[
-                Text(
-                  this.nextButtonText,
-                  style: TextThemes.joinButtonTextChatTab,
-                ),
-                SizedBox(
-                  width: SpacingValues.small,
-                ),
-                Icon(Icons.arrow_forward, color: Colors.black),
-              ],
-            ),
-            backDisable: true,
-            onNext: this.onNext,
-            contents: Expanded(
-              child: Container(
-                color: Colors.transparent,
-                padding: EdgeInsets.all(SpacingValues.extraLarge),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    Container(
-                      child: SvgPicture.asset(
-                        'assets/svg/chat-icon.svg',
-                        width: 80,
-                        color: Colors.white,
-                      ),
-                    ),
-                    SizedBox(
-                      height: SpacingValues.xxLarge,
-                    ),
-                    Text(
-                      Intl.message(
-                          'Your new discussion has been successfully created.'),
-                      style: TextThemes.onboardHeading,
-                      textAlign: TextAlign.center,
-                    ),
-                    SizedBox(
-                      height: SpacingValues.mediumLarge,
-                    ),
-                    Container(
-                      margin:
-                          EdgeInsets.symmetric(horizontal: SpacingValues.large),
+                  backDisable: true,
+                  onNext: this.onNext,
+                  contents: Expanded(
+                    child: Container(
+                      color: Colors.transparent,
+                      padding: EdgeInsets.all(SpacingValues.extraLarge),
                       child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: <Widget>[
                           Container(
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.start,
+                            child: SvgPicture.asset(
+                              'assets/svg/chat-icon.svg',
+                              width: 80,
+                              color: Colors.white,
+                            ),
+                          ),
+                          SizedBox(
+                            height: SpacingValues.xxLarge,
+                          ),
+                          Text(
+                            Intl.message(
+                                'Your new discussion has been successfully created.'),
+                            style: TextThemes.onboardHeading,
+                            textAlign: TextAlign.center,
+                          ),
+                          SizedBox(
+                            height: SpacingValues.mediumLarge,
+                          ),
+                          Container(
+                            margin: EdgeInsets.symmetric(
+                                horizontal: SpacingValues.large),
+                            child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
-                              children: <Widget>[
-                                _BulletPoint(
-                                  color: Colors.white,
-                                  size: TextThemes.onboardBody.fontSize / 1.5,
-                                ),
-                                SizedBox(width: SpacingValues.large),
-                                Flexible(
-                                  child: Column(
+                              children: [
+                                Container(
+                                  child: Row(
                                     mainAxisAlignment: MainAxisAlignment.start,
                                     crossAxisAlignment:
                                         CrossAxisAlignment.start,
                                     children: <Widget>[
-                                      Text(
-                                        info.title,
-                                        style: TextThemes.onboardBody.copyWith(
-                                            fontWeight: FontWeight.bold),
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
+                                      BulletPoint(
+                                        color: Colors.white,
+                                        size: TextThemes.onboardBody.fontSize /
+                                            1.5,
+                                        margin: EdgeInsets.only(
+                                            top: (TextThemes
+                                                        .onboardBody.fontSize /
+                                                    1.5) *
+                                                0.3),
                                       ),
-                                      SizedBox(
-                                        height: SpacingValues.small,
+                                      SizedBox(width: SpacingValues.large),
+                                      Flexible(
+                                        child: Column(
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.start,
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: <Widget>[
+                                            Text(
+                                              state.info.title,
+                                              style: TextThemes.onboardBody
+                                                  .copyWith(
+                                                      fontWeight:
+                                                          FontWeight.bold),
+                                              maxLines: 1,
+                                              overflow: TextOverflow.ellipsis,
+                                            ),
+                                            SizedBox(
+                                              height: SpacingValues.small,
+                                            ),
+                                            (state.info.description?.length ??
+                                                        0) >
+                                                    0
+                                                ? Text(
+                                                    state.info.description,
+                                                    maxLines: 3,
+                                                    overflow:
+                                                        TextOverflow.ellipsis,
+                                                  )
+                                                : Container(),
+                                          ],
+                                        ),
+                                      )
+                                    ],
+                                  ),
+                                ),
+                                SizedBox(
+                                  height: SpacingValues.medium,
+                                ),
+                                Container(
+                                  child: Row(
+                                    mainAxisAlignment: MainAxisAlignment.start,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: <Widget>[
+                                      BulletPoint(
+                                        color: Colors.white,
+                                        size: TextThemes.onboardBody.fontSize /
+                                            1.5,
+                                        margin: EdgeInsets.only(
+                                            top: (TextThemes
+                                                        .onboardBody.fontSize /
+                                                    1.5) *
+                                                0.3),
                                       ),
-                                      Text(
-                                        info.description,
-                                        maxLines: 2,
-                                        overflow: TextOverflow.ellipsis,
-                                      ),
+                                      SizedBox(width: SpacingValues.large),
+                                      Flexible(
+                                        child: Text(
+                                          inviteMode,
+                                          style: TextThemes.onboardBody,
+                                          maxLines: 4,
+                                          overflow: TextOverflow.ellipsis,
+                                        ),
+                                      )
                                     ],
                                   ),
                                 )
@@ -267,143 +185,101 @@ class ConfirmationPage extends StatelessWidget {
                             ),
                           ),
                           SizedBox(
-                            height: SpacingValues.medium,
+                            height: SpacingValues.large,
                           ),
-                          Container(
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.start,
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: <Widget>[
-                                _BulletPoint(
-                                  color: Colors.white,
-                                  size: TextThemes.onboardBody.fontSize / 1.5,
-                                ),
-                                SizedBox(width: SpacingValues.large),
-                                Flexible(
-                                  child: Text(
-                                    inviteMode,
-                                    style: TextThemes.onboardBody,
-                                    maxLines: 4,
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
-                                )
-                              ],
+                          Pressable(
+                            height: 50,
+                            width: double.infinity,
+                            onPressed: () =>
+                                copyInvitationLink(context, state.info),
+                            decoration: BoxDecoration(
+                              shape: BoxShape.rectangle,
+                              borderRadius: BorderRadius.circular(100.0),
                             ),
-                          )
+                            child: Container(
+                              decoration: BoxDecoration(
+                                shape: BoxShape.rectangle,
+                                color: Color.fromRGBO(247, 247, 255, 1.0),
+                                borderRadius: BorderRadius.circular(100.0),
+                              ),
+                              alignment: Alignment.center,
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Icon(
+                                    Icons.content_copy,
+                                    color: Colors.black,
+                                    size: 30,
+                                  ),
+                                  SizedBox(
+                                    width: SpacingValues.smallMedium,
+                                  ),
+                                  Text(
+                                    Intl.message('Copy invitation link'),
+                                    style: TextThemes.signInWithTwitter,
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                          SizedBox(
+                            height: SpacingValues.mediumLarge,
+                          ),
+                          Pressable(
+                            height: 50,
+                            width: double.infinity,
+                            onPressed: () =>
+                                sendInvitationTweet(context, state.info),
+                            decoration: BoxDecoration(
+                              shape: BoxShape.rectangle,
+                              borderRadius: BorderRadius.circular(100.0),
+                            ),
+                            child: Container(
+                              decoration: BoxDecoration(
+                                shape: BoxShape.rectangle,
+                                color: ChathamColors.twitterLogoColor,
+                                borderRadius: BorderRadius.circular(100.0),
+                              ),
+                              alignment: Alignment.center,
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  SvgPicture.asset(
+                                    'assets/svg/twitter_logo.svg',
+                                    color: Colors.black,
+                                    width: 32.0,
+                                    height: 32.0,
+                                  ),
+                                  SizedBox(
+                                    width: SpacingValues.smallMedium,
+                                  ),
+                                  Text(
+                                    Intl.message('Tweet your invite'),
+                                    style: TextThemes.signInWithTwitter,
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
                         ],
                       ),
                     ),
-                    SizedBox(
-                      height: SpacingValues.large,
-                    ),
-                    Pressable(
-                      height: 50,
-                      width: double.infinity,
-                      onPressed: () => copyInvitationLink(context, info),
-                      decoration: BoxDecoration(
-                        shape: BoxShape.rectangle,
-                        borderRadius: BorderRadius.circular(100.0),
-                      ),
-                      child: Container(
-                        decoration: BoxDecoration(
-                          shape: BoxShape.rectangle,
-                          color: Color.fromRGBO(247, 247, 255, 1.0),
-                          borderRadius: BorderRadius.circular(100.0),
-                        ),
-                        alignment: Alignment.center,
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Icon(
-                              Icons.content_copy,
-                              color: Colors.black,
-                              size: 30,
-                            ),
-                            SizedBox(
-                              width: SpacingValues.smallMedium,
-                            ),
-                            Text(
-                              Intl.message('Copy invitation link'),
-                              style: TextThemes.signInWithTwitter,
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                    SizedBox(
-                      height: SpacingValues.mediumLarge,
-                    ),
-                    Pressable(
-                      height: 50,
-                      width: double.infinity,
-                      onPressed: () => sendInvitationTweet(context, info),
-                      decoration: BoxDecoration(
-                        shape: BoxShape.rectangle,
-                        borderRadius: BorderRadius.circular(100.0),
-                      ),
-                      child: Container(
-                        decoration: BoxDecoration(
-                          shape: BoxShape.rectangle,
-                          color: ChathamColors.twitterLogoColor,
-                          borderRadius: BorderRadius.circular(100.0),
-                        ),
-                        alignment: Alignment.center,
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            SvgPicture.asset(
-                              'assets/svg/twitter_logo.svg',
-                              color: Colors.black,
-                              width: 32.0,
-                              height: 32.0,
-                            ),
-                            SizedBox(
-                              width: SpacingValues.smallMedium,
-                            ),
-                            Text(
-                              Intl.message('Tweet your invite'),
-                              style: TextThemes.signInWithTwitter,
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
               ),
             ),
-          ),
-        ),
-      ),
+          );
+        }
+        return Container();
+      },
     );
   }
 
   void sendInvitationTweet(BuildContext context, UpsertDiscussionInfo info) {
-    // TODO: Sent real tweet
+    // TODO: Send real tweet
   }
 
   void copyInvitationLink(BuildContext context, UpsertDiscussionInfo info) {
     // TODO: Copy to clipboard and send notification to user
-  }
-}
-
-class _BulletPoint extends StatelessWidget {
-  final Color color;
-  final double size;
-
-  const _BulletPoint({Key key, @required this.color, @required this.size})
-      : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      margin: EdgeInsets.only(top: size * 0.3),
-      width: size,
-      height: size,
-      decoration: BoxDecoration(
-        color: color,
-        shape: BoxShape.circle,
-      ),
-    );
   }
 }

--- a/lib/screens/upsert_discussion/pages/creation_loading_page.dart
+++ b/lib/screens/upsert_discussion/pages/creation_loading_page.dart
@@ -25,133 +25,129 @@ class CreationLoadingPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<UpsertDiscussionBloc, UpsertDiscussionState>(
       builder: (context, state) {
-        if (state is UpsertDiscussionLoadingState ||
-            state is UpsertDiscussionErrorState) {
-          final height = MediaQuery.of(context).size.height;
-          String title = Intl.message("Loading...");
-          if (state is UpsertDiscussionErrorState) {
-            title = Intl.message("Problem");
-          }
-          Widget content = Container();
-          if (state is UpsertDiscussionLoadingState) {
-            content = Container(
-              child: Center(
-                child: Column(
-                  children: <Widget>[
-                    Text(
-                      Intl.message(
-                          "We are creating your new discussion, please hold on a little longer..."),
-                      style: TextThemes.onboardBody,
-                      textAlign: TextAlign.center,
-                    ),
-                    SizedBox(height: SpacingValues.large),
-                    CircularProgressIndicator()
-                  ],
-                ),
+        final height = MediaQuery.of(context).size.height;
+        String title = Intl.message("Loading...");
+        if (state is UpsertDiscussionErrorState) {
+          title = Intl.message("There is a problem");
+        }
+        Widget content = Container();
+        if (state is UpsertDiscussionLoadingState) {
+          content = Container(
+            child: Center(
+              child: Column(
+                children: <Widget>[
+                  Text(
+                    Intl.message(
+                        "We are creating your new discussion, please hold on a little longer..."),
+                    style: TextThemes.onboardBody,
+                    textAlign: TextAlign.center,
+                  ),
+                  SizedBox(height: SpacingValues.large),
+                  CircularProgressIndicator()
+                ],
               ),
-            );
-          } else if (state is UpsertDiscussionErrorState) {
-            content = Container(
-              child: Center(
-                child: Column(
-                  children: <Widget>[
-                    Text(
-                      Intl.message(
-                          "An error occurred while creating your discussion."),
-                      style: TextThemes.onboardBody,
-                      textAlign: TextAlign.center,
+            ),
+          );
+        } else if (state is UpsertDiscussionErrorState) {
+          content = Container(
+            child: Center(
+              child: Column(
+                children: <Widget>[
+                  Text(
+                    Intl.message(
+                        "An error occurred while creating your discussion."),
+                    style: TextThemes.onboardBody,
+                    textAlign: TextAlign.center,
+                  ),
+                  SizedBox(height: SpacingValues.medium),
+                  Text(
+                    state.error.toString(),
+                    textAlign: TextAlign.center,
+                    style: TextThemes.onboardBody.copyWith(
+                      color: Colors.red,
                     ),
-                    SizedBox(height: SpacingValues.medium),
-                    Text(
-                      state.error.toString(),
-                      textAlign: TextAlign.center,
-                      style: TextThemes.onboardBody.copyWith(
-                        color: Colors.red,
-                      ),
+                  ),
+                  SizedBox(height: SpacingValues.large),
+                  Pressable(
+                    height: 50,
+                    width: double.infinity,
+                    onPressed: this.onRetry,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.rectangle,
+                      borderRadius: BorderRadius.circular(100.0),
                     ),
-                    SizedBox(height: SpacingValues.large),
-                    Pressable(
-                      height: 50,
-                      width: double.infinity,
-                      onPressed: this.onRetry,
+                    child: Container(
                       decoration: BoxDecoration(
                         shape: BoxShape.rectangle,
+                        color: Color.fromRGBO(247, 247, 255, 1.0),
                         borderRadius: BorderRadius.circular(100.0),
                       ),
-                      child: Container(
-                        decoration: BoxDecoration(
-                          shape: BoxShape.rectangle,
-                          color: Color.fromRGBO(247, 247, 255, 1.0),
-                          borderRadius: BorderRadius.circular(100.0),
-                        ),
-                        alignment: Alignment.center,
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Text(
-                              Intl.message('Please try again'),
-                              style: TextThemes.signInWithTwitter,
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                    SizedBox(height: SpacingValues.small),
-                    RaisedButton(
-                      padding: EdgeInsets.symmetric(
-                        horizontal: SpacingValues.xxxxLarge,
-                        vertical: SpacingValues.medium,
-                      ),
-                      shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(25.0)),
-                      color: Color.fromRGBO(247, 247, 255, 0.2),
-                      child: Text(Intl.message("Go back")),
-                      onPressed: this.onBack,
-                      animationDuration: Duration(milliseconds: 100),
-                    ),
-                  ],
-                ),
-              ),
-            );
-          }
-          return Scaffold(
-            body: SingleChildScrollView(
-              child: Container(
-                height: height,
-                decoration: BoxDecoration(
-                  color: Colors.black,
-                ),
-                child: BasePageWidget(
-                  title: title,
-                  backDisable: true,
-                  nextDisable: true,
-                  contents: Expanded(
-                    child: Container(
-                      margin: EdgeInsets.all(SpacingValues.extraLarge),
-                      child: Column(
+                      alignment: Alignment.center,
+                      child: Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          Image.asset(
-                            'assets/images/app_icon/image.png',
-                            width: 96.0,
-                            height: 96.0,
-                          ),
-                          SizedBox(height: SpacingValues.large),
-                          AnimatedSizeContainer(
-                            builder: (context) {
-                              return content;
-                            },
+                          Text(
+                            Intl.message('Please try again'),
+                            style: TextThemes.signInWithTwitter,
                           ),
                         ],
                       ),
                     ),
                   ),
-                ),
+                  SizedBox(height: SpacingValues.small),
+                  RaisedButton(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: SpacingValues.xxxxLarge,
+                      vertical: SpacingValues.medium,
+                    ),
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(25.0)),
+                    color: Color.fromRGBO(247, 247, 255, 0.2),
+                    child: Text(Intl.message("Go back")),
+                    onPressed: this.onBack,
+                    animationDuration: Duration(milliseconds: 100),
+                  ),
+                ],
               ),
             ),
           );
         }
-        return Container();
+        return Scaffold(
+          body: SingleChildScrollView(
+            child: Container(
+              height: height,
+              decoration: BoxDecoration(
+                color: Colors.black,
+              ),
+              child: BasePageWidget(
+                title: title,
+                backDisable: true,
+                nextDisable: true,
+                contents: Expanded(
+                  child: Container(
+                    margin: EdgeInsets.all(SpacingValues.extraLarge),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Image.asset(
+                          'assets/images/app_icon/image.png',
+                          width: 96.0,
+                          height: 96.0,
+                        ),
+                        SizedBox(height: SpacingValues.large),
+                        AnimatedSizeContainer(
+                          builder: (context) {
+                            return content;
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
       },
     );
   }

--- a/lib/screens/upsert_discussion/pages/creation_loading_page.dart
+++ b/lib/screens/upsert_discussion/pages/creation_loading_page.dart
@@ -26,10 +26,6 @@ class CreationLoadingPage extends StatelessWidget {
     return BlocBuilder<UpsertDiscussionBloc, UpsertDiscussionState>(
       builder: (context, state) {
         final height = MediaQuery.of(context).size.height;
-        String title = Intl.message("Loading...");
-        if (state is UpsertDiscussionErrorState) {
-          title = Intl.message("There is a problem");
-        }
         Widget content = Container();
         if (state is UpsertDiscussionLoadingState) {
           content = Container(
@@ -116,33 +112,24 @@ class CreationLoadingPage extends StatelessWidget {
           body: SingleChildScrollView(
             child: Container(
               height: height,
-              decoration: BoxDecoration(
-                color: Colors.black,
-              ),
-              child: BasePageWidget(
-                title: title,
-                backDisable: true,
-                nextDisable: true,
-                contents: Expanded(
-                  child: Container(
-                    margin: EdgeInsets.all(SpacingValues.extraLarge),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Image.asset(
-                          'assets/images/app_icon/image.png',
-                          width: 96.0,
-                          height: 96.0,
-                        ),
-                        SizedBox(height: SpacingValues.large),
-                        AnimatedSizeContainer(
-                          builder: (context) {
-                            return content;
-                          },
-                        ),
-                      ],
+              color: Colors.black,
+              padding: EdgeInsets.all(SpacingValues.extraLarge),
+              child: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Image.asset(
+                      'assets/images/app_icon/image.png',
+                      width: 96.0,
+                      height: 96.0,
                     ),
-                  ),
+                    SizedBox(height: SpacingValues.large),
+                    AnimatedSizeContainer(
+                      builder: (context) {
+                        return content;
+                      },
+                    ),
+                  ],
                 ),
               ),
             ),

--- a/lib/screens/upsert_discussion/pages/creation_loading_page.dart
+++ b/lib/screens/upsert_discussion/pages/creation_loading_page.dart
@@ -1,0 +1,158 @@
+import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
+import 'package:delphis_app/design/sizes.dart';
+import 'package:delphis_app/design/text_theme.dart';
+import 'package:delphis_app/screens/upsert_discussion/pages/base_page_widget.dart';
+import 'package:delphis_app/widgets/animated_size_container/animated_size_container.dart';
+import 'package:delphis_app/widgets/pressable/pressable.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+
+class CreationLoadingPage extends StatelessWidget {
+  final String prevButtonText;
+  final VoidCallback onBack;
+  final VoidCallback onRetry;
+
+  const CreationLoadingPage({
+    Key key,
+    @required this.prevButtonText,
+    @required this.onBack,
+    @required this.onRetry,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<UpsertDiscussionBloc, UpsertDiscussionState>(
+      builder: (context, state) {
+        if (state is UpsertDiscussionLoadingState ||
+            state is UpsertDiscussionErrorState) {
+          final height = MediaQuery.of(context).size.height;
+          String title = Intl.message("Loading...");
+          if (state is UpsertDiscussionErrorState) {
+            title = Intl.message("Problem");
+          }
+          Widget content = Container();
+          if (state is UpsertDiscussionLoadingState) {
+            content = Container(
+              child: Center(
+                child: Column(
+                  children: <Widget>[
+                    Text(
+                      Intl.message(
+                          "We are creating your new discussion, please hold on a little longer..."),
+                      style: TextThemes.onboardBody,
+                      textAlign: TextAlign.center,
+                    ),
+                    SizedBox(height: SpacingValues.large),
+                    CircularProgressIndicator()
+                  ],
+                ),
+              ),
+            );
+          } else if (state is UpsertDiscussionErrorState) {
+            content = Container(
+              child: Center(
+                child: Column(
+                  children: <Widget>[
+                    Text(
+                      Intl.message(
+                          "An error occurred while creating your discussion."),
+                      style: TextThemes.onboardBody,
+                      textAlign: TextAlign.center,
+                    ),
+                    SizedBox(height: SpacingValues.medium),
+                    Text(
+                      state.error.toString(),
+                      textAlign: TextAlign.center,
+                      style: TextThemes.onboardBody.copyWith(
+                        color: Colors.red,
+                      ),
+                    ),
+                    SizedBox(height: SpacingValues.large),
+                    Pressable(
+                      height: 50,
+                      width: double.infinity,
+                      onPressed: this.onRetry,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.rectangle,
+                        borderRadius: BorderRadius.circular(100.0),
+                      ),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          shape: BoxShape.rectangle,
+                          color: Color.fromRGBO(247, 247, 255, 1.0),
+                          borderRadius: BorderRadius.circular(100.0),
+                        ),
+                        alignment: Alignment.center,
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Text(
+                              Intl.message('Please try again'),
+                              style: TextThemes.signInWithTwitter,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    SizedBox(height: SpacingValues.small),
+                    RaisedButton(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: SpacingValues.xxxxLarge,
+                        vertical: SpacingValues.medium,
+                      ),
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(25.0)),
+                      color: Color.fromRGBO(247, 247, 255, 0.2),
+                      child: Text(Intl.message("Go back")),
+                      onPressed: this.onBack,
+                      animationDuration: Duration(milliseconds: 100),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+          return Scaffold(
+            body: SingleChildScrollView(
+              child: Container(
+                height: height,
+                decoration: BoxDecoration(
+                  color: Colors.black,
+                ),
+                child: BasePageWidget(
+                  title: title,
+                  backDisable: true,
+                  nextDisable: true,
+                  contents: Expanded(
+                    child: Container(
+                      margin: EdgeInsets.all(SpacingValues.extraLarge),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Image.asset(
+                            'assets/images/app_icon/image.png',
+                            width: 96.0,
+                            height: 96.0,
+                          ),
+                          SizedBox(height: SpacingValues.large),
+                          AnimatedSizeContainer(
+                            builder: (context) {
+                              return content;
+                            },
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+        }
+        return Container();
+      },
+    );
+  }
+}

--- a/lib/screens/upsert_discussion/pages/invite_mode_page.dart
+++ b/lib/screens/upsert_discussion/pages/invite_mode_page.dart
@@ -1,8 +1,10 @@
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_info.dart';
+import 'package:delphis_app/data/repository/discussion.dart';
 import 'package:delphis_app/design/sizes.dart';
 import 'package:delphis_app/design/text_theme.dart';
 import 'package:delphis_app/screens/upsert_discussion/pages/base_page_widget.dart';
+import 'package:delphis_app/screens/upsert_discussion/widgets/check_list_option.dart';
 import 'package:delphis_app/widgets/animated_size_container/animated_size_container.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -10,10 +12,10 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
 
 class InviteModePage extends StatefulWidget {
-  static final everyoneFollowedText = Intl.message(
-      "Automatically allow everyone I’m following to join, but manually approve everyone else.");
-  static final everyoneApprovedText =
-      Intl.message("Manually approve all requests to join.");
+  static final allowTwitterFriendsText = Intl.message(
+      "Automatically allow everyone I'm following on Twitter to join, but I will manually approve everyone else");
+  static final allRequireApprovalText =
+      Intl.message("I will manually approve all requests to join");
   final String nextButtonText;
   final String prevButtonText;
   final VoidCallback onBack;
@@ -66,7 +68,12 @@ class _InviteModePageState extends State<InviteModePage> {
                 nextButtonChild: nextButton,
                 backButtonChild: Text(this.widget.prevButtonText),
                 onBack: this.widget.onBack,
-                onNext: () => this.onNext(context, state.info),
+                onNext: state.info.inviteMode == null
+                    ? null
+                    : () => this.onNext(context, state.info),
+                nextColor: state.info.inviteMode == null
+                    ? Color.fromRGBO(247, 247, 255, 0.5)
+                    : Color.fromRGBO(247, 247, 255, 1.0),
                 contents: Expanded(
                   child: Container(
                     margin: EdgeInsets.all(SpacingValues.extraLarge),
@@ -75,7 +82,7 @@ class _InviteModePageState extends State<InviteModePage> {
                       children: <Widget>[
                         Text(
                           Intl.message(
-                              'There are many ways for you to decide who can participate in your new chat.'),
+                              'Who would you like to have access to your discussion?'),
                           style: TextThemes.onboardHeading,
                           textAlign: TextAlign.center,
                         ),
@@ -128,31 +135,33 @@ class _InviteModePageState extends State<InviteModePage> {
                         Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: <Widget>[
-                            _ModeOption(
+                            CheckListOption(
                               isSelected: state.info.inviteMode ==
-                                  DiscussionInviteMode.EVERYONE_FOLLOWED,
-                              text: InviteModePage.everyoneFollowedText,
+                                  DiscussionJoinabilitySetting
+                                      .ALLOW_TWITTER_FRIENDS,
+                              text: InviteModePage.allowTwitterFriendsText,
                               onTap: () =>
                                   BlocProvider.of<UpsertDiscussionBloc>(context)
                                       .add(
-                                UpsertDiscussionSetInfoEvent(
-                                    inviteMode:
-                                        DiscussionInviteMode.EVERYONE_FOLLOWED),
+                                UpsertDiscussionSetInviteModeEvent(
+                                    inviteMode: DiscussionJoinabilitySetting
+                                        .ALLOW_TWITTER_FRIENDS),
                               ),
                             ),
                             SizedBox(
                               height: SpacingValues.mediumLarge,
                             ),
-                            _ModeOption(
+                            CheckListOption(
                               isSelected: state.info.inviteMode ==
-                                  DiscussionInviteMode.EVERYONE_APPROVED,
-                              text: InviteModePage.everyoneApprovedText,
+                                  DiscussionJoinabilitySetting
+                                      .ALL_REQUIRE_APPROVAL,
+                              text: InviteModePage.allRequireApprovalText,
                               onTap: () =>
                                   BlocProvider.of<UpsertDiscussionBloc>(context)
                                       .add(
-                                UpsertDiscussionSetInfoEvent(
-                                    inviteMode:
-                                        DiscussionInviteMode.EVERYONE_APPROVED),
+                                UpsertDiscussionSetInviteModeEvent(
+                                    inviteMode: DiscussionJoinabilitySetting
+                                        .ALL_REQUIRE_APPROVAL),
                               ),
                             ),
                           ],
@@ -178,54 +187,5 @@ class _InviteModePageState extends State<InviteModePage> {
         this.widget.onNext();
       }
     });
-  }
-}
-
-class _ModeOption extends StatelessWidget {
-  final bool isSelected;
-  final String text;
-  final VoidCallback onTap;
-
-  const _ModeOption({Key key, this.isSelected, this.text, this.onTap})
-      : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    final checkMarkSize = 24.0;
-    final borderWidth = 2.0;
-    Widget checkMark = Container(
-      margin: EdgeInsets.all(borderWidth),
-      decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          border: Border.all(width: borderWidth, color: Colors.white)),
-      width: checkMarkSize - borderWidth * 2,
-      height: checkMarkSize - borderWidth * 2,
-    );
-    if (this.isSelected) {
-      checkMark =
-          Icon(Icons.check_circle, color: Colors.white, size: checkMarkSize);
-    }
-
-    return Material(
-      color: Colors.transparent,
-      borderRadius: BorderRadius.circular(20.0),
-      clipBehavior: Clip.antiAlias,
-      child: InkWell(
-          onTap: this.onTap,
-          child: Container(
-            padding: EdgeInsets.all(SpacingValues.small),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                checkMark,
-                SizedBox(width: SpacingValues.large),
-                Flexible(
-                  child: Text(this.text, style: TextThemes.onboardBody),
-                )
-              ],
-            ),
-          )),
-    );
   }
 }

--- a/lib/screens/upsert_discussion/pages/invite_mode_page.dart
+++ b/lib/screens/upsert_discussion/pages/invite_mode_page.dart
@@ -1,0 +1,229 @@
+import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
+import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_info.dart';
+import 'package:delphis_app/design/sizes.dart';
+import 'package:delphis_app/design/text_theme.dart';
+import 'package:delphis_app/screens/upsert_discussion/pages/base_page_widget.dart';
+import 'package:delphis_app/widgets/animated_size_container/animated_size_container.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:intl/intl.dart';
+
+class InviteModePage extends StatefulWidget {
+  final String nextButtonText;
+  final String prevButtonText;
+  final VoidCallback onBack;
+  final VoidCallback onNext;
+  final bool isUpdateMode;
+
+  const InviteModePage({
+    Key key,
+    @required this.nextButtonText,
+    @required this.prevButtonText,
+    @required this.onBack,
+    @required this.onNext,
+    @required this.isUpdateMode,
+  }) : super(key: key);
+
+  @override
+  _InviteModePageState createState() => _InviteModePageState();
+}
+
+class _InviteModePageState extends State<InviteModePage> {
+  var error;
+
+  @override
+  Widget build(BuildContext context) {
+    final height = MediaQuery.of(context).size.height;
+    return BlocBuilder<UpsertDiscussionBloc, UpsertDiscussionState>(
+      builder: (context, state) {
+        Widget nextButton = Text(
+          this.widget.nextButtonText,
+          style: TextThemes.joinButtonTextChatTab,
+        );
+        if (!this.widget.isUpdateMode) {
+          nextButton = Row(
+            children: <Widget>[
+              Icon(Icons.add, color: Colors.black),
+              SizedBox(width: SpacingValues.extraSmall),
+              nextButton,
+            ],
+          );
+        }
+
+        return Scaffold(
+          resizeToAvoidBottomInset: true,
+          body: SingleChildScrollView(
+            child: Container(
+              color: Colors.black,
+              height: height,
+              child: BasePageWidget(
+                title: "Invitation Mode",
+                nextButtonChild: nextButton,
+                backButtonChild: Text(this.widget.prevButtonText),
+                onBack: this.widget.onBack,
+                onNext: () => this.onNext(context, state.info),
+                contents: Expanded(
+                  child: Container(
+                    margin: EdgeInsets.all(SpacingValues.extraLarge),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
+                        Text(
+                          Intl.message(
+                              'There are many ways for you to decide who can participate in your new chat.'),
+                          style: TextThemes.onboardHeading,
+                          textAlign: TextAlign.center,
+                        ),
+                        SizedBox(
+                          height: SpacingValues.smallMedium,
+                        ),
+                        Text(
+                          Intl.message(
+                              'Choose how you prefer to manage invitations for this discussion.'),
+                          style: TextThemes.onboardBody,
+                          textAlign: TextAlign.center,
+                        ),
+                        SizedBox(
+                          height: SpacingValues.large,
+                        ),
+                        Container(
+                          child: SvgPicture.asset(
+                            'assets/svg/paper_airplane.svg',
+                            width: 50,
+                            color: Colors.white,
+                          ),
+                        ),
+                        SizedBox(
+                          height: SpacingValues.xxLarge,
+                        ),
+                        AnimatedSizeContainer(
+                          builder: (context) {
+                            if (error != null) {
+                              return Column(
+                                children: [
+                                  Container(
+                                    margin: EdgeInsets.only(
+                                        top: SpacingValues.medium),
+                                    child: Text(
+                                      error.toString(),
+                                      textAlign: TextAlign.center,
+                                      style: TextThemes.discussionPostText
+                                          .copyWith(color: Colors.red),
+                                    ),
+                                  ),
+                                  SizedBox(
+                                    height: SpacingValues.medium,
+                                  ),
+                                ],
+                              );
+                            }
+                            return Container();
+                          },
+                        ),
+                        Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: <Widget>[
+                            _ModeOption(
+                              isSelected: state.info.inviteMode ==
+                                  DiscussionInviteMode.EVERYONE_FOLLOWED,
+                              text: Intl.message(
+                                  "Automatically allow everyone I’m following to join, but manually approve everyone else."),
+                              onTap: () =>
+                                  BlocProvider.of<UpsertDiscussionBloc>(context)
+                                      .add(
+                                UpsertDiscussionSetInfoEvent(
+                                    inviteMode:
+                                        DiscussionInviteMode.EVERYONE_FOLLOWED),
+                              ),
+                            ),
+                            SizedBox(
+                              height: SpacingValues.mediumLarge,
+                            ),
+                            _ModeOption(
+                              isSelected: state.info.inviteMode ==
+                                  DiscussionInviteMode.EVERYONE_APPROVED,
+                              text: Intl.message(
+                                  "Manually approve all requests to join."),
+                              onTap: () =>
+                                  BlocProvider.of<UpsertDiscussionBloc>(context)
+                                      .add(
+                                UpsertDiscussionSetInfoEvent(
+                                    inviteMode:
+                                        DiscussionInviteMode.EVERYONE_APPROVED),
+                              ),
+                            ),
+                          ],
+                        )
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void onNext(BuildContext context, UpsertDiscussionInfo info) {
+    setState(() {
+      this.error = null;
+      if (info.inviteMode == null) {
+        error = Intl.message("You need to specify a preferred option.");
+      } else if (this.widget.onNext != null) {
+        this.widget.onNext();
+      }
+    });
+  }
+}
+
+class _ModeOption extends StatelessWidget {
+  final bool isSelected;
+  final String text;
+  final VoidCallback onTap;
+
+  const _ModeOption({Key key, this.isSelected, this.text, this.onTap})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final checkMarkSize = 24.0;
+    final borderWidth = 2.0;
+    Widget checkMark = Container(
+      margin: EdgeInsets.all(borderWidth),
+      decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          border: Border.all(width: borderWidth, color: Colors.white)),
+      width: checkMarkSize - borderWidth * 2,
+      height: checkMarkSize - borderWidth * 2,
+    );
+    if (this.isSelected) {
+      checkMark =
+          Icon(Icons.check_circle, color: Colors.white, size: checkMarkSize);
+    }
+
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(20.0),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+          onTap: this.onTap,
+          child: Container(
+            padding: EdgeInsets.all(SpacingValues.small),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                checkMark,
+                SizedBox(width: SpacingValues.large),
+                Flexible(
+                  child: Text(this.text, style: TextThemes.onboardBody),
+                )
+              ],
+            ),
+          )),
+    );
+  }
+}

--- a/lib/screens/upsert_discussion/pages/invite_mode_page.dart
+++ b/lib/screens/upsert_discussion/pages/invite_mode_page.dart
@@ -10,6 +10,10 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
 
 class InviteModePage extends StatefulWidget {
+  static final everyoneFollowedText = Intl.message(
+      "Automatically allow everyone I’m following to join, but manually approve everyone else.");
+  static final everyoneApprovedText =
+      Intl.message("Manually approve all requests to join.");
   final String nextButtonText;
   final String prevButtonText;
   final VoidCallback onBack;
@@ -127,8 +131,7 @@ class _InviteModePageState extends State<InviteModePage> {
                             _ModeOption(
                               isSelected: state.info.inviteMode ==
                                   DiscussionInviteMode.EVERYONE_FOLLOWED,
-                              text: Intl.message(
-                                  "Automatically allow everyone I’m following to join, but manually approve everyone else."),
+                              text: InviteModePage.everyoneFollowedText,
                               onTap: () =>
                                   BlocProvider.of<UpsertDiscussionBloc>(context)
                                       .add(
@@ -143,8 +146,7 @@ class _InviteModePageState extends State<InviteModePage> {
                             _ModeOption(
                               isSelected: state.info.inviteMode ==
                                   DiscussionInviteMode.EVERYONE_APPROVED,
-                              text: Intl.message(
-                                  "Manually approve all requests to join."),
+                              text: InviteModePage.everyoneApprovedText,
                               onTap: () =>
                                   BlocProvider.of<UpsertDiscussionBloc>(context)
                                       .add(

--- a/lib/screens/upsert_discussion/pages/title_description_page.dart
+++ b/lib/screens/upsert_discussion/pages/title_description_page.dart
@@ -39,6 +39,9 @@ class _TitleDescriptionPageState extends State<TitleDescriptionPage> {
   @override
   void initState() {
     this.titleController = TextEditingController();
+    this.titleController.addListener(() {
+      setState(() {});
+    });
     this.descriptionController = TextEditingController();
     this.titleController.text = this.widget.initialTitle ?? "";
     this.descriptionController.text = this.widget.initialDescription ?? "";
@@ -69,7 +72,12 @@ class _TitleDescriptionPageState extends State<TitleDescriptionPage> {
             ),
             backButtonChild: Text(this.widget.prevButtonText),
             onBack: this.widget.onBack,
-            onNext: () => this.onNext(context),
+            onNext: (titleController.text?.length ?? 0) == 0
+                ? null
+                : () => this.onNext(context),
+            nextColor: (titleController.text?.length ?? 0) == 0
+                ? Color.fromRGBO(247, 247, 255, 0.5)
+                : Color.fromRGBO(247, 247, 255, 1.0),
             contents: Expanded(
               child: GestureDetector(
                 onTap: () {
@@ -144,6 +152,8 @@ class _TitleDescriptionPageState extends State<TitleDescriptionPage> {
                         textController: this.titleController,
                         hint: Intl.message("A great title..."),
                         autofocus: false,
+                        maxLenght: 50,
+                        showLengthCounter: true,
                       ),
                       SizedBox(
                         height: SpacingValues.small,
@@ -157,6 +167,8 @@ class _TitleDescriptionPageState extends State<TitleDescriptionPage> {
                         hint: Intl.message("A cool description..."),
                         autofocus: false,
                         maxLines: 3,
+                        maxLenght: 140,
+                        showLengthCounter: true,
                       ),
                     ],
                   ),
@@ -176,12 +188,10 @@ class _TitleDescriptionPageState extends State<TitleDescriptionPage> {
       this.error = null;
       if ((title?.length == 0 ?? true)) {
         error = Intl.message("You need to fill the title field.");
-      } else if ((description?.length == 0 ?? true)) {
-        error = Intl.message("You need to fill the description field.");
       }
       if (error == null && this.widget.onNext != null) {
         BlocProvider.of<UpsertDiscussionBloc>(context).add(
-          UpsertDiscussionSetInfoEvent(
+          UpsertDiscussionSetTitleDescriptionEvent(
             description: description,
             title: title,
           ),

--- a/lib/screens/upsert_discussion/pages/title_description_page.dart
+++ b/lib/screens/upsert_discussion/pages/title_description_page.dart
@@ -1,0 +1,179 @@
+import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
+import 'package:delphis_app/design/sizes.dart';
+import 'package:delphis_app/design/text_theme.dart';
+import 'package:delphis_app/screens/upsert_discussion/pages/base_page_widget.dart';
+import 'package:delphis_app/screens/upsert_discussion/widgets/text_field.dart';
+import 'package:delphis_app/widgets/animated_size_container/animated_size_container.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+
+class TitleDescriptionPage extends StatefulWidget {
+  final String nextButtonText;
+  final String prevButtonText;
+  final VoidCallback onBack;
+  final VoidCallback onNext;
+
+  const TitleDescriptionPage({
+    Key key,
+    @required this.nextButtonText,
+    @required this.prevButtonText,
+    @required this.onBack,
+    @required this.onNext,
+  }) : super(key: key);
+
+  @override
+  _TitleDescriptionPageState createState() => _TitleDescriptionPageState();
+}
+
+class _TitleDescriptionPageState extends State<TitleDescriptionPage> {
+  TextEditingController titleController;
+  TextEditingController descriptionController;
+  var error;
+
+  @override
+  void initState() {
+    this.titleController = TextEditingController();
+    this.descriptionController = TextEditingController();
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    this.titleController.dispose();
+    this.descriptionController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final height = MediaQuery.of(context).size.height;
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: Container(
+          height: height,
+          child: BasePageWidget(
+            title: "New Discussion",
+            nextButtonText: this.widget.nextButtonText,
+            backButtonText: this.widget.prevButtonText,
+            onBack: this.widget.onBack,
+            onNext: () => this.onNext(context),
+            contents: Expanded(
+              child: Container(
+                margin: EdgeInsets.all(SpacingValues.extraLarge),
+                child: Column(
+                  children: <Widget>[
+                    Expanded(
+                      flex: 1,
+                      child: Center(
+                          child: Container(
+                        decoration: BoxDecoration(shape: BoxShape.circle),
+                        clipBehavior: Clip.antiAlias,
+                        child: Image.asset(
+                          'assets/images/app_icon/image.png',
+                          width: MediaQuery.of(context).size.width * 0.2,
+                        ),
+                      )),
+                    ),
+                    Expanded(
+                      flex: 1,
+                      child: Center(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: <Widget>[
+                            Text(
+                              Intl.message(
+                                  'This lets you create a new conversation for which you will be the moderator.'),
+                              style: TextThemes.onboardBody,
+                              textAlign: TextAlign.center,
+                            ),
+                            SizedBox(
+                              height: SpacingValues.smallMedium,
+                            ),
+                            Text(
+                              Intl.message(
+                                  'Your identity will be visible to everyone but all participants will be anonymous to each other (and you).'),
+                              style: TextThemes.onboardBody,
+                              textAlign: TextAlign.center,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    AnimatedSizeContainer(
+                      builder: (context) {
+                        if (error != null) {
+                          return Container(
+                            margin: EdgeInsets.only(top: SpacingValues.medium),
+                            child: Text(
+                              error.toString(),
+                              textAlign: TextAlign.center,
+                              style: TextThemes.discussionPostText
+                                  .copyWith(color: Colors.red),
+                            ),
+                          );
+                        }
+                        return Container();
+                      },
+                    ),
+                    Expanded(
+                        flex: 2,
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: <Widget>[
+                            Text(Intl.message('Enter a title for your chat:')),
+                            SizedBox(
+                              height: SpacingValues.extraSmall,
+                            ),
+                            UpsertDiscussionTextField(
+                              textController: this.titleController,
+                              hint: Intl.message("A great title..."),
+                              autofocus: false,
+                            ),
+                            SizedBox(
+                              height: SpacingValues.medium,
+                            ),
+                            Text(Intl.message('A description for your chat:')),
+                            SizedBox(
+                              height: SpacingValues.extraSmall,
+                            ),
+                            UpsertDiscussionTextField(
+                              textController: this.descriptionController,
+                              hint: Intl.message("A cool description..."),
+                              autofocus: false,
+                              maxLines: 4,
+                            ),
+                          ],
+                        )),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void onNext(BuildContext context) {
+    var title = titleController.text;
+    var description = descriptionController.text;
+    setState(() {
+      this.error = null;
+      if ((title?.length == 0 ?? true)) {
+        error = Intl.message("You need to fill the title field.");
+      } else if ((description?.length == 0 ?? true)) {
+        error = Intl.message("You need to fill the description field.");
+      }
+      if (error == null && this.widget.onNext != null) {
+        BlocProvider.of<UpsertDiscussionBloc>(context).add(
+          UpsertDiscussionSetInfoEvent(
+            description: description,
+            title: title,
+          ),
+        );
+        this.widget.onNext();
+      }
+    });
+  }
+}

--- a/lib/screens/upsert_discussion/pages/title_description_page.dart
+++ b/lib/screens/upsert_discussion/pages/title_description_page.dart
@@ -6,6 +6,7 @@ import 'package:delphis_app/screens/upsert_discussion/widgets/text_field.dart';
 import 'package:delphis_app/widgets/animated_size_container/animated_size_container.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
 
 class TitleDescriptionPage extends StatefulWidget {
@@ -70,90 +71,95 @@ class _TitleDescriptionPageState extends State<TitleDescriptionPage> {
             onBack: this.widget.onBack,
             onNext: () => this.onNext(context),
             contents: Expanded(
-              child: Container(
-                margin: EdgeInsets.all(SpacingValues.extraLarge),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    Container(
-                      decoration: BoxDecoration(shape: BoxShape.circle),
-                      clipBehavior: Clip.antiAlias,
-                      child: Image.asset(
-                        'assets/images/app_icon/image.png',
-                        width: MediaQuery.of(context).size.width * 0.2,
+              child: GestureDetector(
+                onTap: () {
+                  FocusScope.of(context).unfocus();
+                },
+                child: Container(
+                  color: Colors.transparent,
+                  padding: EdgeInsets.all(SpacingValues.extraLarge),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      Container(
+                        child: SvgPicture.asset(
+                          'assets/svg/chat-icon.svg',
+                          width: 80,
+                          color: Colors.white,
+                        ),
                       ),
-                    ),
-                    SizedBox(
-                      height: SpacingValues.mediumLarge,
-                    ),
-                    Text(
-                      Intl.message(
-                          'This lets you create a new conversation for which you will be the moderator.'),
-                      style: TextThemes.onboardHeading,
-                      textAlign: TextAlign.center,
-                    ),
-                    SizedBox(
-                      height: SpacingValues.smallMedium,
-                    ),
-                    Text(
-                      Intl.message(
-                          'Your identity will be visible to everyone but all participants will be anonymous to each other (and you).'),
-                      style: TextThemes.onboardBody,
-                      textAlign: TextAlign.center,
-                    ),
-                    SizedBox(
-                      height: SpacingValues.mediumLarge,
-                    ),
-                    AnimatedSizeContainer(
-                      builder: (context) {
-                        if (error != null) {
-                          return Column(
-                            children: [
-                              Container(
-                                margin:
-                                    EdgeInsets.only(top: SpacingValues.medium),
-                                child: Text(
-                                  error.toString(),
-                                  textAlign: TextAlign.center,
-                                  style: TextThemes.discussionPostText
-                                      .copyWith(color: Colors.red),
+                      SizedBox(
+                        height: SpacingValues.xxLarge,
+                      ),
+                      Text(
+                        Intl.message(
+                            'This lets you create a new conversation for which you will be the moderator.'),
+                        style: TextThemes.onboardHeading,
+                        textAlign: TextAlign.center,
+                      ),
+                      SizedBox(
+                        height: SpacingValues.smallMedium,
+                      ),
+                      Text(
+                        Intl.message(
+                            'Your identity will be visible to everyone but all participants will be anonymous to each other (and you).'),
+                        style: TextThemes.onboardBody,
+                        textAlign: TextAlign.center,
+                      ),
+                      SizedBox(
+                        height: SpacingValues.mediumLarge,
+                      ),
+                      AnimatedSizeContainer(
+                        builder: (context) {
+                          if (error != null) {
+                            return Column(
+                              children: [
+                                Container(
+                                  margin: EdgeInsets.only(
+                                      top: SpacingValues.medium),
+                                  child: Text(
+                                    error.toString(),
+                                    textAlign: TextAlign.center,
+                                    style: TextThemes.discussionPostText
+                                        .copyWith(color: Colors.red),
+                                  ),
                                 ),
-                              ),
-                              SizedBox(
-                                height: SpacingValues.medium,
-                              ),
-                            ],
-                          );
-                        }
-                        return Container();
-                      },
-                    ),
-                    SizedBox(
-                      height: SpacingValues.mediumLarge,
-                    ),
-                    Text(Intl.message('Enter a title for your chat:')),
-                    SizedBox(
-                      height: SpacingValues.extraSmall,
-                    ),
-                    UpsertDiscussionTextField(
-                      textController: this.titleController,
-                      hint: Intl.message("A great title..."),
-                      autofocus: false,
-                    ),
-                    SizedBox(
-                      height: SpacingValues.small,
-                    ),
-                    Text(Intl.message('A description for your chat:')),
-                    SizedBox(
-                      height: SpacingValues.extraSmall,
-                    ),
-                    UpsertDiscussionTextField(
-                      textController: this.descriptionController,
-                      hint: Intl.message("A cool description..."),
-                      autofocus: false,
-                      maxLines: 3,
-                    ),
-                  ],
+                                SizedBox(
+                                  height: SpacingValues.medium,
+                                ),
+                              ],
+                            );
+                          }
+                          return Container();
+                        },
+                      ),
+                      SizedBox(
+                        height: SpacingValues.mediumLarge,
+                      ),
+                      Text(Intl.message('Enter a title for your chat:')),
+                      SizedBox(
+                        height: SpacingValues.extraSmall,
+                      ),
+                      UpsertDiscussionTextField(
+                        textController: this.titleController,
+                        hint: Intl.message("A great title..."),
+                        autofocus: false,
+                      ),
+                      SizedBox(
+                        height: SpacingValues.small,
+                      ),
+                      Text(Intl.message('A description for your chat:')),
+                      SizedBox(
+                        height: SpacingValues.extraSmall,
+                      ),
+                      UpsertDiscussionTextField(
+                        textController: this.descriptionController,
+                        hint: Intl.message("A cool description..."),
+                        autofocus: false,
+                        maxLines: 3,
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/screens/upsert_discussion/pages/title_description_page.dart
+++ b/lib/screens/upsert_discussion/pages/title_description_page.dart
@@ -55,6 +55,7 @@ class _TitleDescriptionPageState extends State<TitleDescriptionPage> {
   Widget build(BuildContext context) {
     final height = MediaQuery.of(context).size.height;
     return Scaffold(
+      resizeToAvoidBottomInset: true,
       body: SingleChildScrollView(
         child: Container(
           color: Colors.black,
@@ -72,94 +73,85 @@ class _TitleDescriptionPageState extends State<TitleDescriptionPage> {
               child: Container(
                 margin: EdgeInsets.all(SpacingValues.extraLarge),
                 child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
                   children: <Widget>[
-                    Expanded(
-                      child: Center(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: <Widget>[
-                            Container(
-                              decoration: BoxDecoration(shape: BoxShape.circle),
-                              clipBehavior: Clip.antiAlias,
-                              child: Image.asset(
-                                'assets/images/app_icon/image.png',
-                                width: MediaQuery.of(context).size.width * 0.2,
-                              ),
-                            ),
-                            SizedBox(
-                              height: SpacingValues.mediumLarge,
-                            ),
-                            Text(
-                              Intl.message(
-                                  'This lets you create a new conversation for which you will be the moderator.'),
-                              style: TextThemes.onboardHeading,
-                              textAlign: TextAlign.center,
-                            ),
-                            SizedBox(
-                              height: SpacingValues.smallMedium,
-                            ),
-                            Text(
-                              Intl.message(
-                                  'Your identity will be visible to everyone but all participants will be anonymous to each other (and you).'),
-                              style: TextThemes.onboardBody,
-                              textAlign: TextAlign.center,
-                            ),
-                          ],
-                        ),
+                    Container(
+                      decoration: BoxDecoration(shape: BoxShape.circle),
+                      clipBehavior: Clip.antiAlias,
+                      child: Image.asset(
+                        'assets/images/app_icon/image.png',
+                        width: MediaQuery.of(context).size.width * 0.2,
                       ),
                     ),
-                    Expanded(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: <Widget>[
-                          AnimatedSizeContainer(
-                            builder: (context) {
-                              if (error != null) {
-                                return Column(
-                                  children: [
-                                    Container(
-                                      margin: EdgeInsets.only(
-                                          top: SpacingValues.medium),
-                                      child: Text(
-                                        error.toString(),
-                                        textAlign: TextAlign.center,
-                                        style: TextThemes.discussionPostText
-                                            .copyWith(color: Colors.red),
-                                      ),
-                                    ),
-                                    SizedBox(
-                                      height: SpacingValues.medium,
-                                    ),
-                                  ],
-                                );
-                              }
-                              return Container();
-                            },
-                          ),
-                          Text(Intl.message('Enter a title for your chat:')),
-                          SizedBox(
-                            height: SpacingValues.extraSmall,
-                          ),
-                          UpsertDiscussionTextField(
-                            textController: this.titleController,
-                            hint: Intl.message("A great title..."),
-                            autofocus: false,
-                          ),
-                          SizedBox(
-                            height: SpacingValues.medium,
-                          ),
-                          Text(Intl.message('A description for your chat:')),
-                          SizedBox(
-                            height: SpacingValues.extraSmall,
-                          ),
-                          UpsertDiscussionTextField(
-                            textController: this.descriptionController,
-                            hint: Intl.message("A cool description..."),
-                            autofocus: false,
-                            maxLines: 3,
-                          ),
-                        ],
-                      ),
+                    SizedBox(
+                      height: SpacingValues.mediumLarge,
+                    ),
+                    Text(
+                      Intl.message(
+                          'This lets you create a new conversation for which you will be the moderator.'),
+                      style: TextThemes.onboardHeading,
+                      textAlign: TextAlign.center,
+                    ),
+                    SizedBox(
+                      height: SpacingValues.smallMedium,
+                    ),
+                    Text(
+                      Intl.message(
+                          'Your identity will be visible to everyone but all participants will be anonymous to each other (and you).'),
+                      style: TextThemes.onboardBody,
+                      textAlign: TextAlign.center,
+                    ),
+                    SizedBox(
+                      height: SpacingValues.mediumLarge,
+                    ),
+                    AnimatedSizeContainer(
+                      builder: (context) {
+                        if (error != null) {
+                          return Column(
+                            children: [
+                              Container(
+                                margin:
+                                    EdgeInsets.only(top: SpacingValues.medium),
+                                child: Text(
+                                  error.toString(),
+                                  textAlign: TextAlign.center,
+                                  style: TextThemes.discussionPostText
+                                      .copyWith(color: Colors.red),
+                                ),
+                              ),
+                              SizedBox(
+                                height: SpacingValues.medium,
+                              ),
+                            ],
+                          );
+                        }
+                        return Container();
+                      },
+                    ),
+                    SizedBox(
+                      height: SpacingValues.mediumLarge,
+                    ),
+                    Text(Intl.message('Enter a title for your chat:')),
+                    SizedBox(
+                      height: SpacingValues.extraSmall,
+                    ),
+                    UpsertDiscussionTextField(
+                      textController: this.titleController,
+                      hint: Intl.message("A great title..."),
+                      autofocus: false,
+                    ),
+                    SizedBox(
+                      height: SpacingValues.small,
+                    ),
+                    Text(Intl.message('A description for your chat:')),
+                    SizedBox(
+                      height: SpacingValues.extraSmall,
+                    ),
+                    UpsertDiscussionTextField(
+                      textController: this.descriptionController,
+                      hint: Intl.message("A cool description..."),
+                      autofocus: false,
+                      maxLines: 3,
                     ),
                   ],
                 ),

--- a/lib/screens/upsert_discussion/pages/title_description_page.dart
+++ b/lib/screens/upsert_discussion/pages/title_description_page.dart
@@ -9,6 +9,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
 
 class TitleDescriptionPage extends StatefulWidget {
+  final String initialTitle;
+  final String initialDescription;
   final String nextButtonText;
   final String prevButtonText;
   final VoidCallback onBack;
@@ -20,6 +22,8 @@ class TitleDescriptionPage extends StatefulWidget {
     @required this.prevButtonText,
     @required this.onBack,
     @required this.onNext,
+    this.initialTitle,
+    this.initialDescription,
   }) : super(key: key);
 
   @override
@@ -35,6 +39,8 @@ class _TitleDescriptionPageState extends State<TitleDescriptionPage> {
   void initState() {
     this.titleController = TextEditingController();
     this.descriptionController = TextEditingController();
+    this.titleController.text = this.widget.initialTitle ?? "";
+    this.descriptionController.text = this.widget.initialDescription ?? "";
     super.initState();
   }
 

--- a/lib/screens/upsert_discussion/pages/title_description_page.dart
+++ b/lib/screens/upsert_discussion/pages/title_description_page.dart
@@ -57,11 +57,15 @@ class _TitleDescriptionPageState extends State<TitleDescriptionPage> {
     return Scaffold(
       body: SingleChildScrollView(
         child: Container(
+          color: Colors.black,
           height: height,
           child: BasePageWidget(
             title: "New Discussion",
-            nextButtonText: this.widget.nextButtonText,
-            backButtonText: this.widget.prevButtonText,
+            nextButtonChild: Text(
+              this.widget.nextButtonText,
+              style: TextThemes.joinButtonTextChatTab,
+            ),
+            backButtonChild: Text(this.widget.prevButtonText),
             onBack: this.widget.onBack,
             onNext: () => this.onNext(context),
             contents: Expanded(
@@ -70,27 +74,25 @@ class _TitleDescriptionPageState extends State<TitleDescriptionPage> {
                 child: Column(
                   children: <Widget>[
                     Expanded(
-                      flex: 1,
-                      child: Center(
-                          child: Container(
-                        decoration: BoxDecoration(shape: BoxShape.circle),
-                        clipBehavior: Clip.antiAlias,
-                        child: Image.asset(
-                          'assets/images/app_icon/image.png',
-                          width: MediaQuery.of(context).size.width * 0.2,
-                        ),
-                      )),
-                    ),
-                    Expanded(
-                      flex: 1,
                       child: Center(
                         child: Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: <Widget>[
+                            Container(
+                              decoration: BoxDecoration(shape: BoxShape.circle),
+                              clipBehavior: Clip.antiAlias,
+                              child: Image.asset(
+                                'assets/images/app_icon/image.png',
+                                width: MediaQuery.of(context).size.width * 0.2,
+                              ),
+                            ),
+                            SizedBox(
+                              height: SpacingValues.mediumLarge,
+                            ),
                             Text(
                               Intl.message(
                                   'This lets you create a new conversation for which you will be the moderator.'),
-                              style: TextThemes.onboardBody,
+                              style: TextThemes.onboardHeading,
                               textAlign: TextAlign.center,
                             ),
                             SizedBox(
@@ -106,51 +108,59 @@ class _TitleDescriptionPageState extends State<TitleDescriptionPage> {
                         ),
                       ),
                     ),
-                    AnimatedSizeContainer(
-                      builder: (context) {
-                        if (error != null) {
-                          return Container(
-                            margin: EdgeInsets.only(top: SpacingValues.medium),
-                            child: Text(
-                              error.toString(),
-                              textAlign: TextAlign.center,
-                              style: TextThemes.discussionPostText
-                                  .copyWith(color: Colors.red),
-                            ),
-                          );
-                        }
-                        return Container();
-                      },
-                    ),
                     Expanded(
-                        flex: 2,
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: <Widget>[
-                            Text(Intl.message('Enter a title for your chat:')),
-                            SizedBox(
-                              height: SpacingValues.extraSmall,
-                            ),
-                            UpsertDiscussionTextField(
-                              textController: this.titleController,
-                              hint: Intl.message("A great title..."),
-                              autofocus: false,
-                            ),
-                            SizedBox(
-                              height: SpacingValues.medium,
-                            ),
-                            Text(Intl.message('A description for your chat:')),
-                            SizedBox(
-                              height: SpacingValues.extraSmall,
-                            ),
-                            UpsertDiscussionTextField(
-                              textController: this.descriptionController,
-                              hint: Intl.message("A cool description..."),
-                              autofocus: false,
-                              maxLines: 4,
-                            ),
-                          ],
-                        )),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: <Widget>[
+                          AnimatedSizeContainer(
+                            builder: (context) {
+                              if (error != null) {
+                                return Column(
+                                  children: [
+                                    Container(
+                                      margin: EdgeInsets.only(
+                                          top: SpacingValues.medium),
+                                      child: Text(
+                                        error.toString(),
+                                        textAlign: TextAlign.center,
+                                        style: TextThemes.discussionPostText
+                                            .copyWith(color: Colors.red),
+                                      ),
+                                    ),
+                                    SizedBox(
+                                      height: SpacingValues.medium,
+                                    ),
+                                  ],
+                                );
+                              }
+                              return Container();
+                            },
+                          ),
+                          Text(Intl.message('Enter a title for your chat:')),
+                          SizedBox(
+                            height: SpacingValues.extraSmall,
+                          ),
+                          UpsertDiscussionTextField(
+                            textController: this.titleController,
+                            hint: Intl.message("A great title..."),
+                            autofocus: false,
+                          ),
+                          SizedBox(
+                            height: SpacingValues.medium,
+                          ),
+                          Text(Intl.message('A description for your chat:')),
+                          SizedBox(
+                            height: SpacingValues.extraSmall,
+                          ),
+                          UpsertDiscussionTextField(
+                            textController: this.descriptionController,
+                            hint: Intl.message("A cool description..."),
+                            autofocus: false,
+                            maxLines: 3,
+                          ),
+                        ],
+                      ),
+                    ),
                   ],
                 ),
               ),

--- a/lib/screens/upsert_discussion/pages/twitter_auth_page.dart
+++ b/lib/screens/upsert_discussion/pages/twitter_auth_page.dart
@@ -1,0 +1,118 @@
+import 'package:delphis_app/bloc/auth/auth_bloc.dart';
+import 'package:delphis_app/design/colors.dart';
+import 'package:delphis_app/design/sizes.dart';
+import 'package:delphis_app/design/text_theme.dart';
+import 'package:delphis_app/screens/upsert_discussion/pages/base_page_widget.dart';
+import 'package:delphis_app/widgets/animated_size_container/animated_size_container.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:intl/intl.dart';
+
+class TwitterAuthPage extends StatelessWidget {
+  final String nextButtonText;
+  final String prevButtonText;
+  final VoidCallback onBack;
+  final VoidCallback onNext;
+
+  const TwitterAuthPage({
+    Key key,
+    @required this.nextButtonText,
+    @required this.prevButtonText,
+    @required this.onBack,
+    @required this.onNext,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final twitterWidgetHeight = 76.0;
+    final height = MediaQuery.of(context).size.height;
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: Container(
+          height: height,
+          decoration: BoxDecoration(
+            color: Colors.black,
+          ),
+          child: BasePageWidget(
+            title: "Authentication",
+            nextButtonChild: Row(
+              children: [
+                SvgPicture.asset(
+                  'assets/svg/twitter_logo.svg',
+                  color: ChathamColors.twitterLogoColor,
+                  semanticsLabel: 'Twitter Logo',
+                  width: 28.0,
+                  height: 23.0,
+                ),
+                SizedBox(width: SpacingValues.medium),
+                Text(
+                  this.nextButtonText,
+                  style: TextThemes.joinButtonTextChatTab,
+                ),
+              ],
+            ),
+            backButtonChild: Text(this.prevButtonText),
+            onBack: this.onBack,
+            onNext: () {},
+            contents: Expanded(
+              child: Container(
+                margin: EdgeInsets.all(SpacingValues.extraLarge),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Expanded(
+                      flex: 2,
+                      child: Center(
+                        child: SvgPicture.asset(
+                          'assets/svg/twitter_logo.svg',
+                          color: ChathamColors.signInTwitterBackground,
+                          semanticsLabel: 'Twitter Logo',
+                          width: 96,
+                          height: twitterWidgetHeight,
+                        ),
+                      ),
+                    ),
+                    AnimatedSizeContainer(
+                      builder: (context) {
+                        return BlocBuilder<AuthBloc, AuthState>(
+                          builder: (context, state) {
+                            if (state is LoadingAuthState) {
+                              return CircularProgressIndicator();
+                            }
+                            return Container();
+                          },
+                        );
+                      },
+                    ),
+                    Expanded(
+                      flex: 3,
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                            Intl.message(
+                                "In order to invite a curated list of participants, moderators need to be able to identify themselves so that the participants can trust them."),
+                            style: TextThemes.onboardHeading,
+                            textAlign: TextAlign.center,
+                          ),
+                          SizedBox(height: SpacingValues.mediumLarge),
+                          Text(
+                              Intl.message(
+                                  "You can do so by authenticating through social media for now."),
+                              style: TextThemes.onboardBody,
+                              textAlign: TextAlign.center),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/upsert_discussion/pages/twitter_auth_page.dart
+++ b/lib/screens/upsert_discussion/pages/twitter_auth_page.dart
@@ -105,14 +105,14 @@ class TwitterAuthPage extends StatelessWidget {
                     ),
                     Text(
                       Intl.message(
-                          "In order to invite a curated list of participants, moderators need to be able to identify themselves so that the participants can trust them."),
+                          "In order to invite a curated list of participants, moderators need to be able to identify themselves so that participants can trust them. Chatham identifies its users by using their Twitter identities."),
                       style: TextThemes.onboardHeading,
                       textAlign: TextAlign.center,
                     ),
                     SizedBox(height: SpacingValues.large),
                     Text(
                         Intl.message(
-                            "You can do so by authenticating through social media for now."),
+                            "You can do so by authenticating through Twitter for now."),
                         style: TextThemes.onboardBody,
                         textAlign: TextAlign.center),
                   ],

--- a/lib/screens/upsert_discussion/pages/twitter_auth_page.dart
+++ b/lib/screens/upsert_discussion/pages/twitter_auth_page.dart
@@ -55,7 +55,7 @@ class TwitterAuthPage extends StatelessWidget {
             ),
             backButtonChild: Text(this.prevButtonText),
             onBack: this.onBack,
-            onNext: () {},
+            onNext: this.onNext,
             contents: Expanded(
               child: Container(
                 margin: EdgeInsets.all(SpacingValues.extraLarge),
@@ -75,7 +75,28 @@ class TwitterAuthPage extends StatelessWidget {
                         return BlocBuilder<AuthBloc, AuthState>(
                           builder: (context, state) {
                             if (state is LoadingAuthState) {
-                              return CircularProgressIndicator();
+                              return Container(
+                                margin: EdgeInsets.only(
+                                    bottom: SpacingValues.large),
+                                child: Center(
+                                  child: CircularProgressIndicator(),
+                                ),
+                              );
+                            } else if (state is ErrorAuthState) {
+                              return Container(
+                                margin: EdgeInsets.only(
+                                    bottom: SpacingValues.large),
+                                child: Center(
+                                  child: Text(
+                                    state.error.toString(),
+                                    textAlign: TextAlign.center,
+                                    style:
+                                        TextThemes.discussionPostText.copyWith(
+                                      color: Colors.red,
+                                    ),
+                                  ),
+                                ),
+                              );
                             }
                             return Container();
                           },

--- a/lib/screens/upsert_discussion/pages/twitter_auth_page.dart
+++ b/lib/screens/upsert_discussion/pages/twitter_auth_page.dart
@@ -60,20 +60,16 @@ class TwitterAuthPage extends StatelessWidget {
               child: Container(
                 margin: EdgeInsets.all(SpacingValues.extraLarge),
                 child: Column(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Expanded(
-                      flex: 2,
-                      child: Center(
-                        child: SvgPicture.asset(
-                          'assets/svg/twitter_logo.svg',
-                          color: ChathamColors.signInTwitterBackground,
-                          semanticsLabel: 'Twitter Logo',
-                          width: 96,
-                          height: twitterWidgetHeight,
-                        ),
-                      ),
+                    SvgPicture.asset(
+                      'assets/svg/twitter_logo.svg',
+                      color: ChathamColors.signInTwitterBackground,
+                      semanticsLabel: 'Twitter Logo',
+                      width: 96,
+                      height: twitterWidgetHeight,
                     ),
+                    SizedBox(height: SpacingValues.xxxxLarge),
                     AnimatedSizeContainer(
                       builder: (context) {
                         return BlocBuilder<AuthBloc, AuthState>(
@@ -86,26 +82,18 @@ class TwitterAuthPage extends StatelessWidget {
                         );
                       },
                     ),
-                    Expanded(
-                      flex: 3,
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Text(
-                            Intl.message(
-                                "In order to invite a curated list of participants, moderators need to be able to identify themselves so that the participants can trust them."),
-                            style: TextThemes.onboardHeading,
-                            textAlign: TextAlign.center,
-                          ),
-                          SizedBox(height: SpacingValues.mediumLarge),
-                          Text(
-                              Intl.message(
-                                  "You can do so by authenticating through social media for now."),
-                              style: TextThemes.onboardBody,
-                              textAlign: TextAlign.center),
-                        ],
-                      ),
+                    Text(
+                      Intl.message(
+                          "In order to invite a curated list of participants, moderators need to be able to identify themselves so that the participants can trust them."),
+                      style: TextThemes.onboardHeading,
+                      textAlign: TextAlign.center,
                     ),
+                    SizedBox(height: SpacingValues.large),
+                    Text(
+                        Intl.message(
+                            "You can do so by authenticating through social media for now."),
+                        style: TextThemes.onboardBody,
+                        textAlign: TextAlign.center),
                   ],
                 ),
               ),

--- a/lib/screens/upsert_discussion/screen_arguments.dart
+++ b/lib/screens/upsert_discussion/screen_arguments.dart
@@ -10,12 +10,12 @@ part 'screen_arguments.g.dart';
 class UpsertDiscussionArguments {
   final Discussion discussion;
   final UpsertDiscussionScreenPage firstPage;
-  final bool isSinglePage;
+  final bool isUpdateMode;
 
   const UpsertDiscussionArguments({
     this.discussion,
     this.firstPage = UpsertDiscussionScreenPage.TITLE_DESCRIPTION,
-    this.isSinglePage = false,
+    this.isUpdateMode = false,
   });
 
   factory UpsertDiscussionArguments.fromJsonString(String input) =>

--- a/lib/screens/upsert_discussion/screen_arguments.dart
+++ b/lib/screens/upsert_discussion/screen_arguments.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+
+import 'package:delphis_app/data/repository/discussion.dart';
+import 'package:delphis_app/screens/upsert_discussion/upsert_discussion_screen.dart';
+import 'package:json_annotation/json_annotation.dart' as JsonAnnotation;
+
+part 'screen_arguments.g.dart';
+
+@JsonAnnotation.JsonSerializable()
+class UpsertDiscussionArguments {
+  final Discussion discussion;
+  final UpsertDiscussionScreenPage firstPage;
+  final bool isSinglePage;
+
+  const UpsertDiscussionArguments({
+    this.discussion,
+    this.firstPage = UpsertDiscussionScreenPage.TITLE_DESCRIPTION,
+    this.isSinglePage = false,
+  });
+
+  factory UpsertDiscussionArguments.fromJsonString(String input) =>
+      UpsertDiscussionArguments.fromJson(json.decode(input));
+
+  factory UpsertDiscussionArguments.fromJson(Map<String, dynamic> input) =>
+      _$UpsertDiscussionArgumentsFromJson(input);
+
+  Map<String, dynamic> toJson() => _$UpsertDiscussionArgumentsToJson(this);
+
+  String toJsonString() => json.encode(this.toJson());
+}

--- a/lib/screens/upsert_discussion/screen_arguments.g.dart
+++ b/lib/screens/upsert_discussion/screen_arguments.g.dart
@@ -13,7 +13,8 @@ UpsertDiscussionArguments _$UpsertDiscussionArgumentsFromJson(
         ? null
         : Discussion.fromJson(json['discussion'] as Map<String, dynamic>),
     firstPage: _$enumDecodeNullable(
-        _$UpsertDiscussionScreenPageEnumMap, json['initialPage']),
+        _$UpsertDiscussionScreenPageEnumMap, json['firstPage']),
+    isUpdateMode: json['isUpdateMode'] as bool,
   );
 }
 
@@ -21,7 +22,8 @@ Map<String, dynamic> _$UpsertDiscussionArgumentsToJson(
         UpsertDiscussionArguments instance) =>
     <String, dynamic>{
       'discussion': instance.discussion,
-      'initialPage': _$UpsertDiscussionScreenPageEnumMap[instance.firstPage],
+      'firstPage': _$UpsertDiscussionScreenPageEnumMap[instance.firstPage],
+      'isUpdateMode': instance.isUpdateMode,
     };
 
 T _$enumDecode<T>(

--- a/lib/screens/upsert_discussion/screen_arguments.g.dart
+++ b/lib/screens/upsert_discussion/screen_arguments.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'screen_arguments.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+UpsertDiscussionArguments _$UpsertDiscussionArgumentsFromJson(
+    Map<String, dynamic> json) {
+  return UpsertDiscussionArguments(
+    discussion: json['discussion'] == null
+        ? null
+        : Discussion.fromJson(json['discussion'] as Map<String, dynamic>),
+    firstPage: _$enumDecodeNullable(
+        _$UpsertDiscussionScreenPageEnumMap, json['initialPage']),
+  );
+}
+
+Map<String, dynamic> _$UpsertDiscussionArgumentsToJson(
+        UpsertDiscussionArguments instance) =>
+    <String, dynamic>{
+      'discussion': instance.discussion,
+      'initialPage': _$UpsertDiscussionScreenPageEnumMap[instance.firstPage],
+    };
+
+T _$enumDecode<T>(
+  Map<T, dynamic> enumValues,
+  dynamic source, {
+  T unknownValue,
+}) {
+  if (source == null) {
+    throw ArgumentError('A value must be provided. Supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+
+  final value = enumValues.entries
+      .singleWhere((e) => e.value == source, orElse: () => null)
+      ?.key;
+
+  if (value == null && unknownValue == null) {
+    throw ArgumentError('`$source` is not one of the supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return value ?? unknownValue;
+}
+
+T _$enumDecodeNullable<T>(
+  Map<T, dynamic> enumValues,
+  dynamic source, {
+  T unknownValue,
+}) {
+  if (source == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source, unknownValue: unknownValue);
+}
+
+const _$UpsertDiscussionScreenPageEnumMap = {
+  UpsertDiscussionScreenPage.TITLE_DESCRIPTION: 'TITLE_DESCRIPTION',
+  UpsertDiscussionScreenPage.TWITTER_AUTH: 'TWITTER_AUTH',
+  UpsertDiscussionScreenPage.INVITATION_MODE: 'INVITATION_MODE',
+  UpsertDiscussionScreenPage.CONFIRMATION: 'CONFIRMATION',
+};

--- a/lib/screens/upsert_discussion/upsert_discussion_screen.dart
+++ b/lib/screens/upsert_discussion/upsert_discussion_screen.dart
@@ -1,6 +1,8 @@
 import 'package:delphis_app/bloc/auth/auth_bloc.dart';
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_info.dart';
+import 'package:delphis_app/screens/discussion/screen_args/discussion.dart';
+import 'package:delphis_app/screens/upsert_discussion/pages/confirmation_page.dart';
 import 'package:delphis_app/screens/upsert_discussion/pages/invite_mode_page.dart';
 import 'package:delphis_app/screens/upsert_discussion/pages/title_description_page.dart';
 import 'package:delphis_app/screens/upsert_discussion/pages/twitter_auth_page.dart';
@@ -92,8 +94,16 @@ class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
           isUpdateMode: this.widget.arguments.isUpdateMode,
         );
       case UpsertDiscussionScreenPage.CONFIRMATION:
-        // TODO: Handle this case.
-        break;
+        return ConfirmationPage(
+          onBack: () => this.onBack(context, info, page),
+          onNext: () => this.onNext(context, info, page),
+          prevButtonText: Intl.message("Back"),
+          nextButtonText: Intl.message("Go to chat"),
+          onRetry: () {
+            BlocProvider.of<UpsertDiscussionBloc>(context)
+                .add(UpsertDiscussionCreateDiscussionEvent());
+          },
+        );
     }
     return Container();
   }
@@ -115,7 +125,9 @@ class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
         });
         break;
       case UpsertDiscussionScreenPage.CONFIRMATION:
-        // TODO: Handle this case.
+        setState(() {
+          this.currentPage = UpsertDiscussionScreenPage.INVITATION_MODE;
+        });
         break;
     }
   }
@@ -141,10 +153,19 @@ class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
       case UpsertDiscussionScreenPage.INVITATION_MODE:
         setState(() {
           this.currentPage = UpsertDiscussionScreenPage.CONFIRMATION;
+          BlocProvider.of<UpsertDiscussionBloc>(context)
+              .add(UpsertDiscussionCreateDiscussionEvent());
         });
         break;
       case UpsertDiscussionScreenPage.CONFIRMATION:
-        // TODO: Handle this case.
+        Navigator.of(context).pushNamedAndRemoveUntil(
+          '/Discussion',
+          ModalRoute.withName("/Home"),
+          arguments: DiscussionArguments(
+            discussionID: info.discussion.id,
+            isStartJoinFlow: false,
+          ),
+        );
         break;
     }
   }

--- a/lib/screens/upsert_discussion/upsert_discussion_screen.dart
+++ b/lib/screens/upsert_discussion/upsert_discussion_screen.dart
@@ -3,6 +3,7 @@ import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_info.dart';
 import 'package:delphis_app/screens/discussion/screen_args/discussion.dart';
 import 'package:delphis_app/screens/upsert_discussion/pages/confirmation_page.dart';
+import 'package:delphis_app/screens/upsert_discussion/pages/creation_loading_page.dart';
 import 'package:delphis_app/screens/upsert_discussion/pages/invite_mode_page.dart';
 import 'package:delphis_app/screens/upsert_discussion/pages/title_description_page.dart';
 import 'package:delphis_app/screens/upsert_discussion/pages/twitter_auth_page.dart';
@@ -94,14 +95,26 @@ class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
           isUpdateMode: this.widget.arguments.isUpdateMode,
         );
       case UpsertDiscussionScreenPage.CONFIRMATION:
-        return ConfirmationPage(
-          onBack: () => this.onBack(context, info, page),
-          onNext: () => this.onNext(context, info, page),
-          prevButtonText: Intl.message("Back"),
-          nextButtonText: Intl.message("Go to chat"),
-          onRetry: () {
-            BlocProvider.of<UpsertDiscussionBloc>(context)
-                .add(UpsertDiscussionCreateDiscussionEvent());
+        return BlocBuilder<UpsertDiscussionBloc, UpsertDiscussionState>(
+          builder: (context, state) {
+            if (state is UpsertDiscussionErrorState ||
+                state is UpsertDiscussionLoadingState) {
+              return CreationLoadingPage(
+                  onBack: () => this.onBack(context, info, page),
+                  prevButtonText: Intl.message("Back"),
+                  onRetry: () {
+                    BlocProvider.of<UpsertDiscussionBloc>(context).add(
+                      UpsertDiscussionCreateDiscussionEvent(),
+                    );
+                  });
+            } else {
+              return ConfirmationPage(
+                onBack: () => this.onBack(context, info, page),
+                onNext: () => this.onNext(context, info, page),
+                prevButtonText: Intl.message("Back"),
+                nextButtonText: Intl.message("Go to chat"),
+              );
+            }
           },
         );
     }

--- a/lib/screens/upsert_discussion/upsert_discussion_screen.dart
+++ b/lib/screens/upsert_discussion/upsert_discussion_screen.dart
@@ -1,0 +1,113 @@
+import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
+import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_info.dart';
+import 'package:delphis_app/screens/upsert_discussion/pages/title_description_page.dart';
+import 'package:delphis_app/screens/upsert_discussion/screen_arguments.dart';
+import 'package:delphis_app/widgets/animated_size_container/animated_size_container.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+
+enum UpsertDiscussionScreenPage {
+  TITLE_DESCRIPTION,
+  TWITTER_AUTH,
+  INVITATION_MODE,
+  CONFIRMATION
+}
+
+class UpsertDiscussionScreen extends StatefulWidget {
+  final UpsertDiscussionArguments arguments;
+
+  const UpsertDiscussionScreen({Key key, this.arguments}) : super(key: key);
+  @override
+  _UpsertDiscussionScreenState createState() => _UpsertDiscussionScreenState();
+}
+
+class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
+  UpsertDiscussionScreenPage currentPage;
+
+  @override
+  void initState() {
+    currentPage = this.widget.arguments.firstPage ??
+        UpsertDiscussionScreenPage.TITLE_DESCRIPTION;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<UpsertDiscussionBloc, UpsertDiscussionState>(
+      builder: (context, state) {
+        return AnimatedSizeContainer(
+          builder: (context) {
+            return mapPageToWidget(context, state.info, this.currentPage);
+          },
+        );
+      },
+    );
+  }
+
+  Widget mapPageToWidget(BuildContext context, UpsertDiscussionInfo info,
+      UpsertDiscussionScreenPage page) {
+    switch (page) {
+      case UpsertDiscussionScreenPage.TITLE_DESCRIPTION:
+        return TitleDescriptionPage(
+          onBack: () => this.onBack(context, info, page),
+          onNext: () => this.onNext(context, info, page),
+          prevButtonText: Intl.message("Back"),
+          nextButtonText: Intl.message("Continue"),
+        );
+      case UpsertDiscussionScreenPage.TWITTER_AUTH:
+        // TODO: Handle this case.
+        break;
+      case UpsertDiscussionScreenPage.INVITATION_MODE:
+        // TODO: Handle this case.
+        break;
+      case UpsertDiscussionScreenPage.CONFIRMATION:
+        // TODO: Handle this case.
+        break;
+    }
+    return Container();
+  }
+
+  void onBack(BuildContext context, UpsertDiscussionInfo info,
+      UpsertDiscussionScreenPage page) {
+    switch (page) {
+      case UpsertDiscussionScreenPage.TITLE_DESCRIPTION:
+        Navigator.of(context).pop();
+        break;
+      case UpsertDiscussionScreenPage.TWITTER_AUTH:
+        // TODO: Handle this case.
+        break;
+      case UpsertDiscussionScreenPage.INVITATION_MODE:
+        // TODO: Handle this case.
+        break;
+      case UpsertDiscussionScreenPage.CONFIRMATION:
+        // TODO: Handle this case.
+        break;
+    }
+  }
+
+  void onNext(BuildContext context, UpsertDiscussionInfo info,
+      UpsertDiscussionScreenPage page) {
+    // TODO: Handle Update case
+    switch (page) {
+      case UpsertDiscussionScreenPage.TITLE_DESCRIPTION:
+        setState(() {
+          if (info.meUser == null || !info.meUser.isTwitterAuth) {
+            this.currentPage = UpsertDiscussionScreenPage.TWITTER_AUTH;
+          } else {
+            this.currentPage = UpsertDiscussionScreenPage.INVITATION_MODE;
+          }
+        });
+        break;
+      case UpsertDiscussionScreenPage.TWITTER_AUTH:
+        // TODO: Handle this case.
+        break;
+      case UpsertDiscussionScreenPage.INVITATION_MODE:
+        // TODO: Handle this case.
+        break;
+      case UpsertDiscussionScreenPage.CONFIRMATION:
+        // TODO: Handle this case.
+        break;
+    }
+  }
+}

--- a/lib/screens/upsert_discussion/upsert_discussion_screen.dart
+++ b/lib/screens/upsert_discussion/upsert_discussion_screen.dart
@@ -1,6 +1,7 @@
 import 'package:delphis_app/bloc/auth/auth_bloc.dart';
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_info.dart';
+import 'package:delphis_app/screens/upsert_discussion/pages/invite_mode_page.dart';
 import 'package:delphis_app/screens/upsert_discussion/pages/title_description_page.dart';
 import 'package:delphis_app/screens/upsert_discussion/pages/twitter_auth_page.dart';
 import 'package:delphis_app/screens/upsert_discussion/screen_arguments.dart';
@@ -83,8 +84,13 @@ class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
             ));
         break;
       case UpsertDiscussionScreenPage.INVITATION_MODE:
-        // TODO: Handle this case.
-        break;
+        return InviteModePage(
+          onBack: () => this.onBack(context, info, page),
+          onNext: () => this.onNext(context, info, page),
+          prevButtonText: Intl.message("Back"),
+          nextButtonText: Intl.message("Create"),
+          isUpdateMode: this.widget.arguments.isUpdateMode,
+        );
       case UpsertDiscussionScreenPage.CONFIRMATION:
         // TODO: Handle this case.
         break;
@@ -104,7 +110,9 @@ class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
         });
         break;
       case UpsertDiscussionScreenPage.INVITATION_MODE:
-        // TODO: Handle this case.
+        setState(() {
+          this.currentPage = UpsertDiscussionScreenPage.TITLE_DESCRIPTION;
+        });
         break;
       case UpsertDiscussionScreenPage.CONFIRMATION:
         // TODO: Handle this case.
@@ -131,7 +139,9 @@ class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
         });
         break;
       case UpsertDiscussionScreenPage.INVITATION_MODE:
-        // TODO: Handle this case.
+        setState(() {
+          this.currentPage = UpsertDiscussionScreenPage.CONFIRMATION;
+        });
         break;
       case UpsertDiscussionScreenPage.CONFIRMATION:
         // TODO: Handle this case.

--- a/lib/screens/upsert_discussion/upsert_discussion_screen.dart
+++ b/lib/screens/upsert_discussion/upsert_discussion_screen.dart
@@ -47,6 +47,7 @@ class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
 
   Widget mapPageToWidget(BuildContext context, UpsertDiscussionInfo info,
       UpsertDiscussionScreenPage page) {
+    final isUpdate = this.widget.arguments.isUpdateMode;
     switch (page) {
       case UpsertDiscussionScreenPage.TITLE_DESCRIPTION:
         return TitleDescriptionPage(
@@ -54,6 +55,8 @@ class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
           onNext: () => this.onNext(context, info, page),
           prevButtonText: Intl.message("Back"),
           nextButtonText: Intl.message("Continue"),
+          initialTitle: isUpdate ? info.discussion.title : null,
+          initialDescription: isUpdate ? info.discussion.description : null,
         );
       case UpsertDiscussionScreenPage.TWITTER_AUTH:
         // TODO: Handle this case.

--- a/lib/screens/upsert_discussion/upsert_discussion_screen.dart
+++ b/lib/screens/upsert_discussion/upsert_discussion_screen.dart
@@ -1,3 +1,4 @@
+import 'package:delphis_app/bloc/auth/auth_bloc.dart';
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_info.dart';
 import 'package:delphis_app/screens/upsert_discussion/pages/title_description_page.dart';
@@ -65,12 +66,21 @@ class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
           initialDescription: description,
         );
       case UpsertDiscussionScreenPage.TWITTER_AUTH:
-        return TwitterAuthPage(
-          onBack: () => this.onBack(context, info, page),
-          onNext: () => this.onNext(context, info, page),
-          prevButtonText: Intl.message("Back"),
-          nextButtonText: Intl.message("Sign in with Twitter"),
-        );
+        return BlocListener<AuthBloc, AuthState>(
+            listener: (context, state) {
+              if (state is SignedInAuthState && this.onNext != null) {
+                this.onNext(context, info, page);
+              }
+            },
+            child: TwitterAuthPage(
+              onBack: () => this.onBack(context, info, page),
+              onNext: () {
+                BlocProvider.of<AuthBloc>(context)
+                    .add(TwitterSignInAuthEvent());
+              },
+              prevButtonText: Intl.message("Back"),
+              nextButtonText: Intl.message("Sign in with Twitter"),
+            ));
         break;
       case UpsertDiscussionScreenPage.INVITATION_MODE:
         // TODO: Handle this case.
@@ -104,11 +114,11 @@ class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
 
   void onNext(BuildContext context, UpsertDiscussionInfo info,
       UpsertDiscussionScreenPage page) {
-    // TODO: Handle Update case
+    // TODO: Handle Update case when we need to show only one page
     switch (page) {
       case UpsertDiscussionScreenPage.TITLE_DESCRIPTION:
         setState(() {
-          if (true || info.meUser == null || !info.meUser.isTwitterAuth) {
+          if (info.meUser == null || !info.meUser.isTwitterAuth) {
             this.currentPage = UpsertDiscussionScreenPage.TWITTER_AUTH;
           } else {
             this.currentPage = UpsertDiscussionScreenPage.INVITATION_MODE;
@@ -116,7 +126,9 @@ class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
         });
         break;
       case UpsertDiscussionScreenPage.TWITTER_AUTH:
-        // TODO: Handle this case.
+        setState(() {
+          this.currentPage = UpsertDiscussionScreenPage.INVITATION_MODE;
+        });
         break;
       case UpsertDiscussionScreenPage.INVITATION_MODE:
         // TODO: Handle this case.

--- a/lib/screens/upsert_discussion/upsert_discussion_screen.dart
+++ b/lib/screens/upsert_discussion/upsert_discussion_screen.dart
@@ -1,6 +1,7 @@
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
 import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_info.dart';
 import 'package:delphis_app/screens/upsert_discussion/pages/title_description_page.dart';
+import 'package:delphis_app/screens/upsert_discussion/pages/twitter_auth_page.dart';
 import 'package:delphis_app/screens/upsert_discussion/screen_arguments.dart';
 import 'package:delphis_app/widgets/animated_size_container/animated_size_container.dart';
 import 'package:flutter/material.dart';
@@ -50,16 +51,26 @@ class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
     final isUpdate = this.widget.arguments.isUpdateMode;
     switch (page) {
       case UpsertDiscussionScreenPage.TITLE_DESCRIPTION:
+        final title =
+            (isUpdate || (info.title?.length ?? 0) > 0) ? info.title : null;
+        final description = (isUpdate || (info.description?.length ?? 0) > 0)
+            ? info.description
+            : null;
         return TitleDescriptionPage(
           onBack: () => this.onBack(context, info, page),
           onNext: () => this.onNext(context, info, page),
           prevButtonText: Intl.message("Back"),
           nextButtonText: Intl.message("Continue"),
-          initialTitle: isUpdate ? info.discussion.title : null,
-          initialDescription: isUpdate ? info.discussion.description : null,
+          initialTitle: title,
+          initialDescription: description,
         );
       case UpsertDiscussionScreenPage.TWITTER_AUTH:
-        // TODO: Handle this case.
+        return TwitterAuthPage(
+          onBack: () => this.onBack(context, info, page),
+          onNext: () => this.onNext(context, info, page),
+          prevButtonText: Intl.message("Back"),
+          nextButtonText: Intl.message("Sign in with Twitter"),
+        );
         break;
       case UpsertDiscussionScreenPage.INVITATION_MODE:
         // TODO: Handle this case.
@@ -78,7 +89,9 @@ class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
         Navigator.of(context).pop();
         break;
       case UpsertDiscussionScreenPage.TWITTER_AUTH:
-        // TODO: Handle this case.
+        setState(() {
+          this.currentPage = UpsertDiscussionScreenPage.TITLE_DESCRIPTION;
+        });
         break;
       case UpsertDiscussionScreenPage.INVITATION_MODE:
         // TODO: Handle this case.
@@ -95,7 +108,7 @@ class _UpsertDiscussionScreenState extends State<UpsertDiscussionScreen> {
     switch (page) {
       case UpsertDiscussionScreenPage.TITLE_DESCRIPTION:
         setState(() {
-          if (info.meUser == null || !info.meUser.isTwitterAuth) {
+          if (true || info.meUser == null || !info.meUser.isTwitterAuth) {
             this.currentPage = UpsertDiscussionScreenPage.TWITTER_AUTH;
           } else {
             this.currentPage = UpsertDiscussionScreenPage.INVITATION_MODE;

--- a/lib/screens/upsert_discussion/widgets/bullet_point.dart
+++ b/lib/screens/upsert_discussion/widgets/bullet_point.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class BulletPoint extends StatelessWidget {
+  final Color color;
+  final double size;
+  final EdgeInsets margin;
+
+  const BulletPoint({
+    Key key,
+    @required this.color,
+    @required this.size,
+    @required this.margin,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: margin,
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+      ),
+    );
+  }
+}

--- a/lib/screens/upsert_discussion/widgets/check_list_option.dart
+++ b/lib/screens/upsert_discussion/widgets/check_list_option.dart
@@ -1,0 +1,52 @@
+import 'package:delphis_app/design/sizes.dart';
+import 'package:delphis_app/design/text_theme.dart';
+import 'package:flutter/material.dart';
+
+class CheckListOption extends StatelessWidget {
+  final bool isSelected;
+  final String text;
+  final VoidCallback onTap;
+
+  const CheckListOption({Key key, this.isSelected, this.text, this.onTap})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final checkMarkSize = 24.0;
+    final borderWidth = 2.0;
+    Widget checkMark = Container(
+      margin: EdgeInsets.all(borderWidth),
+      decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          border: Border.all(width: borderWidth, color: Colors.white)),
+      width: checkMarkSize - borderWidth * 2,
+      height: checkMarkSize - borderWidth * 2,
+    );
+    if (this.isSelected) {
+      checkMark =
+          Icon(Icons.check_circle, color: Colors.white, size: checkMarkSize);
+    }
+
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(20.0),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+          onTap: this.onTap,
+          child: Container(
+            padding: EdgeInsets.all(SpacingValues.small),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                checkMark,
+                SizedBox(width: SpacingValues.large),
+                Flexible(
+                  child: Text(this.text, style: TextThemes.onboardBody),
+                )
+              ],
+            ),
+          )),
+    );
+  }
+}

--- a/lib/screens/upsert_discussion/widgets/error_box.dart
+++ b/lib/screens/upsert_discussion/widgets/error_box.dart
@@ -1,0 +1,20 @@
+import 'package:delphis_app/design/sizes.dart';
+import 'package:flutter/material.dart';
+
+class ErrorBox extends StatelessWidget {
+  final Widget child;
+
+  const ErrorBox({Key key, @required this.child}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        color: Colors.red,
+      ),
+      padding: EdgeInsets.all(SpacingValues.smallMedium),
+      child: child,
+    );
+  }
+}

--- a/lib/screens/upsert_discussion/widgets/text_field.dart
+++ b/lib/screens/upsert_discussion/widgets/text_field.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+class UpsertDiscussionTextField extends StatelessWidget {
+  final String hint;
+  final Function(String) onChanged;
+  final TextEditingController textController;
+  final int maxLines;
+  final bool autofocus;
+
+  const UpsertDiscussionTextField({
+    Key key,
+    @required this.hint,
+    this.onChanged,
+    @required this.textController,
+    this.maxLines = 1,
+    this.autofocus = true,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    var textStyle = Theme.of(context).textTheme.bodyText2;
+    var hintStyle = textStyle.copyWith(color: Color.fromRGBO(81, 82, 88, 1.0));
+    return TextField(
+      autofocus: autofocus,
+      showCursor: true,
+      controller: this.textController,
+      decoration: InputDecoration(
+        counter: Container(),
+        contentPadding: EdgeInsets.symmetric(horizontal: 20, vertical: 13.0),
+        hintStyle: hintStyle,
+        hintText: this.hint,
+        fillColor: Color.fromRGBO(57, 58, 63, 1.0),
+        filled: true,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(25.0),
+          borderSide: BorderSide(color: Colors.transparent),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(25.0),
+          borderSide: BorderSide(color: Colors.transparent),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(25.0),
+          borderSide: BorderSide(color: Colors.transparent),
+        ),
+      ),
+      keyboardType: TextInputType.multiline,
+      maxLines: this.maxLines,
+      maxLength: 60,
+      onChanged: onChanged,
+    );
+  }
+}

--- a/lib/screens/upsert_discussion/widgets/text_field.dart
+++ b/lib/screens/upsert_discussion/widgets/text_field.dart
@@ -6,6 +6,8 @@ class UpsertDiscussionTextField extends StatelessWidget {
   final TextEditingController textController;
   final int maxLines;
   final bool autofocus;
+  final int maxLenght;
+  final bool showLengthCounter;
 
   const UpsertDiscussionTextField({
     Key key,
@@ -14,6 +16,8 @@ class UpsertDiscussionTextField extends StatelessWidget {
     @required this.textController,
     this.maxLines = 1,
     this.autofocus = true,
+    this.maxLenght = 50,
+    this.showLengthCounter = false,
   }) : super(key: key);
 
   @override
@@ -21,11 +25,12 @@ class UpsertDiscussionTextField extends StatelessWidget {
     var textStyle = Theme.of(context).textTheme.bodyText2;
     var hintStyle = textStyle.copyWith(color: Color.fromRGBO(81, 82, 88, 1.0));
     return TextField(
+      maxLengthEnforced: true,
       autofocus: autofocus,
       showCursor: true,
       controller: this.textController,
       decoration: InputDecoration(
-        counter: Container(),
+        counter: this.showLengthCounter ? null : Container(),
         contentPadding: EdgeInsets.symmetric(horizontal: 20, vertical: 13.0),
         hintStyle: hintStyle,
         hintText: this.hint,
@@ -46,7 +51,7 @@ class UpsertDiscussionTextField extends StatelessWidget {
       ),
       keyboardType: TextInputType.multiline,
       maxLines: this.maxLines,
-      maxLength: 60,
+      maxLength: maxLenght,
       onChanged: onChanged,
     );
   }


### PR DESCRIPTION
ADDRESSES CHAT-6, CHAT-7, CHAT-8, CHAT-10, CHAT-11, CHAT-13, CHAT-20, CHAT-50 

The following has been achieved:
- Chat creation/modification logic encoded in a BLoC, and separated to the UI page-based flow
- Authentication flow has been unified in a BLoC. This allows for reusability and error handling/user feedback. Apple login is still encoded in UI widgets and will require additional work to be ported. Will take care of it in a separated PR.
- Every UI page of the chat creation flow: Title/Description, Twitter auth, Invitation mode selection, creation/loading, confirmation
- Animations and error handling all around the place for a better UX
- String input length checks
- Sliding animation between pages
- Integration with backend
- Automatic tweet with invitation link in confirmation page