### PR TITLE
Slider and action buttons on chat list

### DIFF
--- a/lib/design/colors.dart
+++ b/lib/design/colors.dart
@@ -350,4 +350,8 @@ class ChathamColors {
       ],
     ),
   };
+
+  static final Color muteChatSlideButtonColor = Colors.blueGrey;
+  static final Color archiveChatSlideButtonColor = Colors.greenAccent;
+  static final Color deleteChatSlideButtonColor = Colors.redAccent;
 }

--- a/lib/design/colors.dart
+++ b/lib/design/colors.dart
@@ -352,6 +352,6 @@ class ChathamColors {
   };
 
   static final Color muteChatSlideButtonColor = Colors.blueGrey;
-  static final Color archiveChatSlideButtonColor = Colors.greenAccent;
+  static final Color archiveChatSlideButtonColor = Colors.green;
   static final Color deleteChatSlideButtonColor = Colors.redAccent;
 }

--- a/lib/screens/home_page/chats/chats_list.dart
+++ b/lib/screens/home_page/chats/chats_list.dart
@@ -137,6 +137,12 @@ class ChatsList extends StatelessWidget {
                     onPressed: () {
                       this.onDiscussionPressed(discussionElem);
                     },
+                    onArchivePressed: () {
+                      // TODO: Hook it up to BLoC and repositories
+                    },
+                    onMutePressed: () {
+                      // TODO: Hook it up to BLoC and repositories
+                    },
                   );
                 },
               );

--- a/lib/screens/home_page/chats/chats_list.dart
+++ b/lib/screens/home_page/chats/chats_list.dart
@@ -7,25 +7,32 @@ import 'package:delphis_app/screens/home_page/home_page.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:intl/intl.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
 
 class ChatsList extends StatelessWidget {
   final Duration durationBeforeAutoRefresh;
   final DiscussionCallback onJoinDiscussionPressed;
-  final DiscussionCallback onDeleteDiscussionInvitePressed;
+  final DiscussionCallback onDeleteDiscussionPressed;
+  final DiscussionCallback onArchiveDiscussionPressed;
+  final DiscussionCallback onMuteDiscussionPressed;
   final DiscussionCallback onDiscussionPressed;
   final RefreshController refreshController;
   final User currentUser;
+  final SlidableController slidableController;
 
   ChatsList({
     Key key,
     @required this.refreshController,
     @required this.onJoinDiscussionPressed,
-    @required this.onDeleteDiscussionInvitePressed,
+    @required this.onDeleteDiscussionPressed,
+    @required this.onArchiveDiscussionPressed,
+    @required this.onMuteDiscussionPressed,
     @required this.onDiscussionPressed,
     @required this.currentUser,
     this.durationBeforeAutoRefresh,
+    this.slidableController,
   }) : super(key: key);
 
   Widget build(BuildContext context) {
@@ -128,20 +135,21 @@ class ChatsList extends StatelessWidget {
                   return SingleChat(
                     discussion: discussionElem,
                     canJoinDiscussions: currentUser?.isTwitterAuth ?? false,
+                    slidableController: this.slidableController,
                     onJoinPressed: () {
                       this.onJoinDiscussionPressed(discussionElem);
                     },
                     onDeletePressed: () {
-                      this.onDeleteDiscussionInvitePressed(discussionElem);
+                      this.onDeleteDiscussionPressed(discussionElem);
                     },
                     onPressed: () {
                       this.onDiscussionPressed(discussionElem);
                     },
                     onArchivePressed: () {
-                      // TODO: Hook it up to BLoC and repositories
+                      this.onArchiveDiscussionPressed(discussionElem);
                     },
                     onMutePressed: () {
-                      // TODO: Hook it up to BLoC and repositories
+                      this.onMuteDiscussionPressed(discussionElem);
                     },
                   );
                 },

--- a/lib/screens/home_page/chats/chats_screen.dart
+++ b/lib/screens/home_page/chats/chats_screen.dart
@@ -4,8 +4,8 @@ import 'package:delphis_app/data/repository/user.dart';
 import 'package:delphis_app/screens/discussion/screen_args/discussion.dart';
 import 'package:delphis_app/screens/home_page/chats/chats_list.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
 
 class ChatsScreen extends StatefulWidget {
@@ -26,11 +26,12 @@ class ChatsScreen extends StatefulWidget {
 class _ChatsScreenState extends State<ChatsScreen> with RouteAware {
   RefreshController _refreshController;
   GlobalKey _chatListKey;
-  DiscussionListBloc discussionListBloc;
+  SlidableController slidableController;
 
   @override
   void dispose() {
     this.widget.routeObserver.unsubscribe(this);
+    this.slidableController?.activeState?.dispose();
     super.dispose();
   }
 
@@ -38,6 +39,7 @@ class _ChatsScreenState extends State<ChatsScreen> with RouteAware {
   void initState() {
     super.initState();
 
+    this.slidableController = SlidableController();
     this._refreshController = RefreshController(initialRefresh: false);
     this._chatListKey = GlobalKey();
   }
@@ -50,20 +52,13 @@ class _ChatsScreenState extends State<ChatsScreen> with RouteAware {
 
   @override
   void didPopNext() {
-    this.discussionListBloc?.add(DiscussionListFetchEvent());
+    BlocProvider.of<DiscussionListBloc>(context)
+        .add(DiscussionListFetchEvent());
     super.didPopNext();
   }
 
   @override
   Widget build(BuildContext context) {
-    if (this.discussionListBloc == null) {
-      SchedulerBinding.instance.addPostFrameCallback((_) async {
-        setState(() {
-          this.discussionListBloc =
-              BlocProvider.of<DiscussionListBloc>(context);
-        });
-      });
-    }
     return ChatsList(
       currentUser: this.widget.currentUser,
       key: this._chatListKey,
@@ -75,10 +70,19 @@ class _ChatsScreenState extends State<ChatsScreen> with RouteAware {
               isStartJoinFlow: true,
             ));
       },
-      onDeleteDiscussionInvitePressed: (Discussion discussion) {},
       onDiscussionPressed: (Discussion discussion) {
         Navigator.of(context).pushNamed('/Discussion',
             arguments: DiscussionArguments(discussionID: discussion.id));
+      },
+      slidableController: slidableController,
+      onDeleteDiscussionPressed: (Discussion discussion) {
+        // TODO: Hook this up to backend mutations somehow
+      },
+      onArchiveDiscussionPressed: (Discussion discussion) {
+        // TODO: Hook this up to backend mutations somehow
+      },
+      onMuteDiscussionPressed: (Discussion discussion) {
+        // TODO: Hook this up to backend mutations somehow
       },
     );
   }

--- a/lib/screens/home_page/chats/single_chat.dart
+++ b/lib/screens/home_page/chats/single_chat.dart
@@ -1,7 +1,9 @@
 import 'package:delphis_app/data/repository/discussion.dart';
+import 'package:delphis_app/design/colors.dart';
 import 'package:delphis_app/screens/home_page/chats/single_chat_joined.dart';
 import 'package:delphis_app/screens/home_page/chats/single_chat_unjoined.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
 
 class SingleChat extends StatelessWidget {
   final Discussion discussion;
@@ -9,6 +11,8 @@ class SingleChat extends StatelessWidget {
   final VoidCallback onDeletePressed;
   final VoidCallback onJoinPressed;
   final VoidCallback onPressed;
+  final VoidCallback onArchivePressed;
+  final VoidCallback onMutePressed;
 
   const SingleChat({
     @required this.discussion,
@@ -16,6 +20,8 @@ class SingleChat extends StatelessWidget {
     @required this.onJoinPressed,
     @required this.onPressed,
     @required this.canJoinDiscussions,
+    @required this.onArchivePressed,
+    @required this.onMutePressed,
   }) : super();
 
   @override
@@ -38,13 +44,40 @@ class SingleChat extends StatelessWidget {
         onPressed: this.onPressed,
       );
     }
-    return DecoratedBox(
+
+    return Slidable(
+      actionPane: SlidableDrawerActionPane(),
+      actionExtentRatio: 0.15,
+      child: DecoratedBox(
         decoration: BoxDecoration(
           border: Border(
             bottom:
                 BorderSide(color: Color.fromRGBO(22, 23, 28, 1.0), width: 1.0),
           ),
         ),
-        child: contents);
+        child: contents,
+      ),
+      actions: <Widget>[],
+      secondaryActions: <Widget>[
+        IconSlideAction(
+          caption: 'Delete',
+          color: ChathamColors.deleteChatSlideButtonColor,
+          icon: Icons.delete,
+          onTap: this.onDeletePressed,
+        ),
+        IconSlideAction(
+          caption: 'Mute',
+          color: ChathamColors.muteChatSlideButtonColor,
+          icon: Icons.volume_off,
+          onTap: this.onMutePressed,
+        ),
+        IconSlideAction(
+          caption: 'Archive',
+          icon: Icons.archive,
+          color: ChathamColors.archiveChatSlideButtonColor,
+          onTap: this.onArchivePressed,
+        ),
+      ],
+    );
   }
 }

--- a/lib/screens/home_page/chats/single_chat.dart
+++ b/lib/screens/home_page/chats/single_chat.dart
@@ -13,6 +13,7 @@ class SingleChat extends StatelessWidget {
   final VoidCallback onPressed;
   final VoidCallback onArchivePressed;
   final VoidCallback onMutePressed;
+  final SlidableController slidableController;
 
   const SingleChat({
     @required this.discussion,
@@ -22,6 +23,7 @@ class SingleChat extends StatelessWidget {
     @required this.canJoinDiscussions,
     @required this.onArchivePressed,
     @required this.onMutePressed,
+    this.slidableController,
   }) : super();
 
   @override
@@ -48,6 +50,8 @@ class SingleChat extends StatelessWidget {
     return Slidable(
       actionPane: SlidableDrawerActionPane(),
       actionExtentRatio: 0.15,
+      controller: this.slidableController,
+      closeOnScroll: true,
       child: DecoratedBox(
         decoration: BoxDecoration(
           border: Border(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -321,6 +321,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
+  flutter_slidable:
+    dependency: "direct main"
+    description:
+      name: flutter_slidable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.5"
   flutter_svg:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   image: ^2.1.12
   photo_view: ^0.9.2
   recase: ^3.0.0
+  flutter_slidable: ^0.5.5
 
   flutter_webview_plugin: 0.3.10+1
   provider: ^4.1.3


### PR DESCRIPTION
ADDRESSES CHAT-37, CHAT-38

This implements the "mute", "archive", and "delete" action buttons on the chat list for each discussion. Each chat is slideable to the left, and the buttons appear with a sliding animation. Also, a minor optimization the chat list has been introduced preventing a useless additional build for storing a BLoC instance in widget's state.

NOTE: This is UI-only, the buttons aren't hooked up to any business-logic yet

<img src="https://user-images.githubusercontent.com/13836700/89178985-16561000-d58f-11ea-992f-fdfd899fa638.png" width="375" /> 
