### PR TITLE
Chat-list action buttons logic implementation

### DIFF
--- a/lib/bloc/discussion_list/discussion_list_bloc.dart
+++ b/lib/bloc/discussion_list/discussion_list_bloc.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:bloc/bloc.dart';
 import 'package:delphis_app/bloc/me/me_bloc.dart';
@@ -23,16 +24,107 @@ class DiscussionListBloc
   Stream<DiscussionListState> mapEventToState(
     DiscussionListEvent event,
   ) async* {
+    // TODO: Format user-friendly errors
     var prevList = this.state.discussionList;
-    if(event is DiscussionListFetchEvent && !(this.state is DiscussionListLoading)) {
+    if (event is DiscussionListFetchEvent &&
+        !(this.state is DiscussionListLoading)) {
+      yield DiscussionListLoading(
+        discussionList: prevList,
+        timestamp: DateTime.now(),
+      );
       try {
-        yield DiscussionListLoading(discussionList: prevList, timestamp: DateTime.now());
         var newList = await this.repository.getDiscussionList();
-        yield DiscussionListLoaded(discussionList: newList, timestamp: DateTime.now());
+        yield DiscussionListLoaded(
+          discussionList: newList,
+          timestamp: DateTime.now(),
+        );
+      } catch (error) {
+        yield DiscussionListError(
+          discussionList: prevList,
+          error: error,
+          timestamp: DateTime.now(),
+        );
       }
-      catch (error) {
-        // TODO: Format user-friendly error
-        yield DiscussionListError(discussionList: prevList, error: error,timestamp: DateTime.now());
+    } else if (event is DiscussionListDeleteEvent) {
+      var listWithoutElement =
+          prevList.where((e) => e.id != event.discussion.id).toList();
+      /* Yield list excluding the element to be removed. This can provide
+         a better UX, as the user thinks that the removal happened istantaneously.
+         we add it back with an error message in case something goes wrong. */
+      yield DiscussionListLoading(
+        discussionList: listWithoutElement,
+        timestamp: DateTime.now(),
+      );
+      try {
+        /* TODO: This is mocked behavior for UI testing. We need to hook this
+           up with repositories and real backend mutations. */
+        Future.delayed(Duration(seconds: 2));
+        if (Random().nextInt(3) == 0) {
+          throw "some random error";
+        }
+
+        /* Yield list excluding the removed element */
+        yield DiscussionListLoaded(
+          discussionList: listWithoutElement,
+          timestamp: DateTime.now(),
+        );
+      } catch (error) {
+        /* Yield list including the element we failed to remove */
+        yield DiscussionListError(
+          discussionList: prevList,
+          error: error,
+          timestamp: DateTime.now(),
+        );
+      }
+    } else if (event is DiscussionListMuteEvent) {
+      yield DiscussionListLoading(
+        discussionList: prevList,
+        timestamp: DateTime.now(),
+      );
+      try {
+        /* TODO: This is mocked behavior for UI testing. We need to hook this
+           up with repositories and real backend mutations. */
+        Future.delayed(Duration(seconds: 2));
+        if (Random().nextInt(3) == 0) {
+          throw "some random error";
+        }
+
+        /* Yield list with updated element */
+        yield DiscussionListLoaded(
+          discussionList: prevList,
+          timestamp: DateTime.now(),
+        );
+      } catch (error) {
+        yield DiscussionListError(
+          discussionList: prevList,
+          error: error,
+          timestamp: DateTime.now(),
+        );
+      }
+    } else if (event is DiscussionListArchiveEvent) {
+      yield DiscussionListLoading(
+        discussionList: prevList,
+        timestamp: DateTime.now(),
+      );
+      try {
+        /* TODO: This is mocked behavior for UI testing. We need to hook this
+           up with repositories and real backend mutations. */
+        Future.delayed(Duration(seconds: 2));
+        if (Random().nextInt(3) == 0) {
+          throw "some random error";
+        }
+
+        /* Yield list with updated element */
+        yield DiscussionListLoaded(
+          discussionList: prevList,
+          timestamp: DateTime.now(),
+        );
+      } catch (error) {
+        yield DiscussionListError(
+          discussionList: prevList,
+          error: error,
+          timestamp: DateTime.now(),
+        );
       }
     }
   }

--- a/lib/bloc/discussion_list/discussion_list_bloc.dart
+++ b/lib/bloc/discussion_list/discussion_list_bloc.dart
@@ -46,86 +46,144 @@ class DiscussionListBloc
         );
       }
     } else if (event is DiscussionListDeleteEvent) {
-      var listWithoutElement =
-          prevList.where((e) => e.id != event.discussion.id).toList();
-      /* Yield list excluding the element to be removed. This can provide
-         a better UX, as the user thinks that the removal happened istantaneously.
-         we add it back with an error message in case something goes wrong. */
-      yield DiscussionListLoading(
+      /* In order to provide a more responsive UX, we want to make the user
+         believe that the requested action happened instantly. For the same
+         reason we consume this event even if the current state is "loading". 
+         To achieve this, we yield a "loaded" state that simulates a successful
+         outcome of the requested operation. The real task is then executed as
+         an async function, which fires an "error" event to this bloc only in
+         case something goes wrong. Those "error" events are not visible outside
+         of this class scope. */
+      var listWithoutElement = prevList.map((e) {
+        if (e.id == event.discussion.id) {
+          return e.copyWith(isDeletedLocally: true);
+        }
+        return e;
+      }).toList();
+      yield DiscussionListLoaded(
         discussionList: listWithoutElement,
         timestamp: DateTime.now(),
       );
-      try {
-        /* TODO: This is mocked behavior for UI testing. We need to hook this
+      () async {
+        try {
+          /* TODO: This is mocked behavior for UI testing. We need to hook this
            up with repositories and real backend mutations. */
-        Future.delayed(Duration(seconds: 2));
-        if (Random().nextInt(3) == 0) {
-          throw "some random error";
+          await Future.delayed(Duration(seconds: 2));
+          if (Random().nextInt(3) == 0) {
+            throw "some random error";
+          }
+          this.add(_DiscussionListDeleteAsyncSuccessEvent(event.discussion));
+        } catch (error) {
+          this.add(
+              _DiscussionListDeleteAsyncErrorEvent(event.discussion, error));
         }
-
-        /* Yield list excluding the removed element */
-        yield DiscussionListLoaded(
-          discussionList: listWithoutElement,
-          timestamp: DateTime.now(),
-        );
-      } catch (error) {
-        /* Yield list including the element we failed to remove */
-        yield DiscussionListError(
-          discussionList: prevList,
-          error: error,
-          timestamp: DateTime.now(),
-        );
-      }
-    } else if (event is DiscussionListMuteEvent) {
-      yield DiscussionListLoading(
-        discussionList: prevList,
+      }();
+    } else if (event is _DiscussionListDeleteAsyncErrorEvent) {
+      /* This event is asynchronously fired by this bloc internally in case 
+         something went wrong with the requested operation. We restore the
+         changes that we pretended to be successful, and yield an error state
+         accordingly. */
+      var updatedList = prevList.map((e) {
+        if (e.id == event.discussion.id) {
+          return e.copyWith(isDeletedLocally: false);
+        }
+        return e;
+      }).toList();
+      yield DiscussionListError(
+        discussionList: updatedList,
+        error: event.error,
         timestamp: DateTime.now(),
       );
-      try {
-        /* TODO: This is mocked behavior for UI testing. We need to hook this
-           up with repositories and real backend mutations. */
-        Future.delayed(Duration(seconds: 2));
-        if (Random().nextInt(3) == 0) {
-          throw "some random error";
-        }
-
-        /* Yield list with updated element */
-        yield DiscussionListLoaded(
-          discussionList: prevList,
-          timestamp: DateTime.now(),
-        );
-      } catch (error) {
-        yield DiscussionListError(
-          discussionList: prevList,
-          error: error,
-          timestamp: DateTime.now(),
-        );
-      }
+    } else if (event is _DiscussionListDeleteAsyncSuccessEvent) {
+      /* This event is asynchronously fired by this bloc internally in case 
+         everything has been executed flawlessly. We finalize the changes
+         requested. */
+      var updatedList =
+          prevList.where((e) => e.id == event.discussion.id).toList();
+      yield DiscussionListLoaded(
+        discussionList: updatedList,
+        timestamp: DateTime.now(),
+      );
     } else if (event is DiscussionListArchiveEvent) {
-      yield DiscussionListLoading(
-        discussionList: prevList,
+      /* See comments reported on DiscussionListDeleteEvent event handler. */
+      var wasArchived = false;
+      var updatedList = prevList.map((e) {
+        if (e.id == event.discussion.id) {
+          // TODO: Apply local transformation and change the required flags
+          // TODO: wasArchived = ??? retrieve it from object
+        }
+        return e;
+      }).toList();
+      yield DiscussionListLoaded(
+        discussionList: updatedList,
         timestamp: DateTime.now(),
       );
-      try {
-        /* TODO: This is mocked behavior for UI testing. We need to hook this
+      () async {
+        try {
+          /* TODO: This is mocked behavior for UI testing. We need to hook this
            up with repositories and real backend mutations. */
-        Future.delayed(Duration(seconds: 2));
-        if (Random().nextInt(3) == 0) {
-          throw "some random error";
+          await Future.delayed(Duration(seconds: 2));
+          if (Random().nextInt(3) == 0) {
+            throw "some random error";
+          }
+        } catch (error) {
+          this.add(_DiscussionListArchiveAsyncErrorEvent(
+              event.discussion, wasArchived, error));
         }
-
-        /* Yield list with updated element */
-        yield DiscussionListLoaded(
-          discussionList: prevList,
-          timestamp: DateTime.now(),
-        );
-      } catch (error) {
-        yield DiscussionListError(
-          discussionList: prevList,
-          error: error,
-          timestamp: DateTime.now(),
-        );
-      }
+      }();
+    } else if (event is _DiscussionListArchiveAsyncErrorEvent) {
+      /* See comments reported on _DiscussionListArchiveAsyncErrorEvent event handler */
+      var updatedList = prevList.map((e) {
+        if (e.id == event.discussion.id) {
+          // TODO: Restore old "archived" flag value using event.wasArchived
+        }
+        return e;
+      }).toList();
+      yield DiscussionListError(
+        discussionList: updatedList,
+        error: event.error,
+        timestamp: DateTime.now(),
+      );
+    } else if (event is DiscussionListMuteEvent) {
+      /* See comments reported on DiscussionListDeleteEvent event handler. */
+      var wasMuted = false;
+      var updatedList = prevList.map((e) {
+        if (e.id == event.discussion.id) {
+          // TODO: Apply local transformation and change the required flags
+          // TODO: wasMuted = ??? retrieve it from object
+        }
+        return e;
+      }).toList();
+      yield DiscussionListLoaded(
+        discussionList: updatedList,
+        timestamp: DateTime.now(),
+      );
+      () async {
+        try {
+          /* TODO: This is mocked behavior for UI testing. We need to hook this
+           up with repositories and real backend mutations. */
+          await Future.delayed(Duration(seconds: 2));
+          if (Random().nextInt(3) == 0) {
+            throw "some random error";
+          }
+        } catch (error) {
+          this.add(_DiscussionListMuteAsyncErrorEvent(
+              event.discussion, wasMuted, error));
+        }
+      }();
+    } else if (event is _DiscussionListMuteAsyncErrorEvent) {
+      /* See comments reported on _DiscussionListArchiveAsyncErrorEvent event handler */
+      var updatedList = prevList.map((e) {
+        if (e.id == event.discussion.id) {
+          // TODO: Restore old "muted" flag value using event.wasArchived
+        }
+        return e;
+      }).toList();
+      yield DiscussionListError(
+        discussionList: updatedList,
+        error: event.error,
+        timestamp: DateTime.now(),
+      );
     }
   }
 }

--- a/lib/bloc/discussion_list/discussion_list_event.dart
+++ b/lib/bloc/discussion_list/discussion_list_event.dart
@@ -27,6 +27,31 @@ class DiscussionListDeleteEvent extends DiscussionListEvent {
   List<Object> get props => [this.now, this.discussion];
 }
 
+class _DiscussionListDeleteAsyncErrorEvent extends DiscussionListEvent {
+  final DateTime now;
+  final Discussion discussion;
+  final error;
+
+  _DiscussionListDeleteAsyncErrorEvent(this.discussion, this.error)
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props => [this.now, this.discussion, this.error];
+}
+
+class _DiscussionListDeleteAsyncSuccessEvent extends DiscussionListEvent {
+  final DateTime now;
+  final Discussion discussion;
+
+  _DiscussionListDeleteAsyncSuccessEvent(this.discussion)
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props => [this.now, this.discussion];
+}
+
 class DiscussionListArchiveEvent extends DiscussionListEvent {
   final DateTime now;
   final Discussion discussion;
@@ -40,6 +65,22 @@ class DiscussionListArchiveEvent extends DiscussionListEvent {
   List<Object> get props => [this.now, this.discussion, this.archived];
 }
 
+class _DiscussionListArchiveAsyncErrorEvent extends DiscussionListEvent {
+  final DateTime now;
+  final Discussion discussion;
+  final bool wasArchived;
+  final error;
+
+  _DiscussionListArchiveAsyncErrorEvent(
+      this.discussion, this.wasArchived, this.error)
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props =>
+      [this.now, this.discussion, this.wasArchived, this.error];
+}
+
 class DiscussionListMuteEvent extends DiscussionListEvent {
   final DateTime now;
   final Discussion discussion;
@@ -51,4 +92,19 @@ class DiscussionListMuteEvent extends DiscussionListEvent {
 
   @override
   List<Object> get props => [this.now, this.discussion, this.muted];
+}
+
+class _DiscussionListMuteAsyncErrorEvent extends DiscussionListEvent {
+  final DateTime now;
+  final Discussion discussion;
+  final bool wasMuted;
+  final error;
+
+  _DiscussionListMuteAsyncErrorEvent(this.discussion, this.wasMuted, this.error)
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props =>
+      [this.now, this.discussion, this.wasMuted, this.error];
 }

--- a/lib/bloc/discussion_list/discussion_list_event.dart
+++ b/lib/bloc/discussion_list/discussion_list_event.dart
@@ -14,3 +14,41 @@ class DiscussionListFetchEvent extends DiscussionListEvent {
   @override
   List<Object> get props => [this.now];
 }
+
+class DiscussionListDeleteEvent extends DiscussionListEvent {
+  final DateTime now;
+  final Discussion discussion;
+
+  DiscussionListDeleteEvent(this.discussion)
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props => [this.now, this.discussion];
+}
+
+class DiscussionListArchiveEvent extends DiscussionListEvent {
+  final DateTime now;
+  final Discussion discussion;
+  final bool archived;
+
+  DiscussionListArchiveEvent(this.discussion, this.archived)
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props => [this.now, this.discussion, this.archived];
+}
+
+class DiscussionListMuteEvent extends DiscussionListEvent {
+  final DateTime now;
+  final Discussion discussion;
+  final bool muted;
+
+  DiscussionListMuteEvent(this.discussion, this.muted)
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props => [this.now, this.discussion, this.muted];
+}

--- a/lib/bloc/discussion_list/discussion_list_state.dart
+++ b/lib/bloc/discussion_list/discussion_list_state.dart
@@ -34,7 +34,7 @@ class DiscussionListLoading extends DiscussionListHasTimestamp {
   final DateTime timestamp;
 
   DiscussionListLoading({
-     @required this.discussionList,
+    @required this.discussionList,
     @required this.timestamp,
   }) : super();
 

--- a/lib/data/repository/discussion.dart
+++ b/lib/data/repository/discussion.dart
@@ -1,3 +1,9 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:json_annotation/json_annotation.dart' as JsonAnnotation;
+
 import 'package:delphis_app/bloc/gql_client/gql_client_bloc.dart';
 import 'package:delphis_app/data/provider/mutations.dart';
 import 'package:delphis_app/data/provider/queries.dart';
@@ -5,17 +11,12 @@ import 'package:delphis_app/data/provider/subscriptions.dart';
 import 'package:delphis_app/data/repository/discussion_creation_settings.dart';
 import 'package:delphis_app/data/repository/discussion_subscription.dart';
 import 'package:delphis_app/data/repository/historical_string.dart';
-import 'package:equatable/equatable.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
-import 'package:graphql_flutter/graphql_flutter.dart';
-import 'package:json_annotation/json_annotation.dart' as JsonAnnotation;
 
+import 'entity.dart';
 import 'moderator.dart';
 import 'participant.dart';
 import 'post.dart';
 import 'post_content_input.dart';
-import 'entity.dart';
 
 part 'discussion.g.dart';
 
@@ -515,6 +516,9 @@ class Discussion extends Equatable implements Entity {
   @JsonAnnotation.JsonKey(ignore: true)
   List<Post> postsCache;
 
+  @JsonAnnotation.JsonKey(ignore: true)
+  bool isDeletedLocally;
+
   @override
   List<Object> get props => [
         id,
@@ -532,6 +536,7 @@ class Discussion extends Equatable implements Entity {
         titleHistory,
         descriptionHistory,
         discussionJoinability,
+        isDeletedLocally,
       ];
 
   Discussion({
@@ -552,6 +557,7 @@ class Discussion extends Equatable implements Entity {
     this.descriptionHistory,
     this.discussionJoinability,
     postsCache,
+    this.isDeletedLocally = false,
   }) : this.postsCache =
             postsCache ?? (postsConnection?.asPostList() ?? List());
 
@@ -563,40 +569,49 @@ class Discussion extends Equatable implements Entity {
   }
 
   Discussion copyWith({
-    PostsConnection postsConnection,
-    Participant meParticipant,
-    List<Participant> participants,
-    List<Participant> meAvailableParticipants,
+    String id,
     Moderator moderator,
+    AnonymityType anonymityType,
+    PostsConnection postsConnection,
+    List<Participant> participants,
+    String title,
+    String createdAt,
+    String updatedAt,
+    Participant meParticipant,
+    List<Participant> meAvailableParticipants,
+    String iconURL,
     DiscussionLinkAccess discussionLinksAccess,
     String description,
     List<HistoricalString> titleHistory,
     List<HistoricalString> descriptionHistory,
     DiscussionJoinabilitySetting discussionJoinability,
     List<Post> postsCache,
-  }) =>
-      Discussion(
-        id: this.id,
-        moderator: moderator ?? this.moderator,
-        anonymityType: this.anonymityType,
-        participants: participants ?? this.participants,
-        title: this.title,
-        createdAt: this.createdAt,
-        updatedAt: this.updatedAt,
-        postsConnection: postsConnection ?? this.postsConnection,
-        meParticipant: meParticipant ?? this.meParticipant,
-        meAvailableParticipants:
-            meAvailableParticipants ?? this.meAvailableParticipants,
-        iconURL: this.iconURL,
-        discussionLinksAccess:
-            discussionLinksAccess ?? this.discussionLinksAccess,
-        description: description ?? this.description,
-        titleHistory: titleHistory ?? this.titleHistory,
-        descriptionHistory: descriptionHistory ?? this.descriptionHistory,
-        discussionJoinability:
-            discussionJoinability ?? this.discussionJoinability,
-        postsCache: postsCache ?? this.postsCache,
-      );
+    bool isDeletedLocally,
+  }) {
+    return Discussion(
+      id: id ?? this.id,
+      moderator: moderator ?? this.moderator,
+      anonymityType: anonymityType ?? this.anonymityType,
+      postsConnection: postsConnection ?? this.postsConnection,
+      participants: participants ?? this.participants,
+      title: title ?? this.title,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      meParticipant: meParticipant ?? this.meParticipant,
+      meAvailableParticipants:
+          meAvailableParticipants ?? this.meAvailableParticipants,
+      iconURL: iconURL ?? this.iconURL,
+      discussionLinksAccess:
+          discussionLinksAccess ?? this.discussionLinksAccess,
+      description: description ?? this.description,
+      titleHistory: titleHistory ?? this.titleHistory,
+      descriptionHistory: descriptionHistory ?? this.descriptionHistory,
+      discussionJoinability:
+          discussionJoinability ?? this.discussionJoinability,
+      postsCache: postsCache ?? this.postsCache,
+      isDeletedLocally: isDeletedLocally ?? this.isDeletedLocally,
+    );
+  }
 
   void addLocalPost(LocalPost post) {
     this.postsCache.insert(0, post.post);


### PR DESCRIPTION
ADDRESSES CHAT-37, CHAT-38. COMPLEMENTARY WITH #118 

This implement the business logic related to the mute, archive, and delete actions on discussions in the chat list. This is totally decoupled from the UI and needs to be integrated with it later. Also this is not integrated with the backend yet. Those changes will be addressed in other PRs. The logic here is slightly complex because, in order to have a good UX, we need to consume action events asynchronously. In other words, when users deletes/mutes/archives a chat we don't want them to wait for the previous mutation to be completed before deleting/muting/archiving other chats. This has been implemented internally in the BLoC, and as such each operation is effectively non-blocking. A successful state is emitted in the stream at first, and errors are propagated later in error states in case they effectively occur.