### PR TITLE
Home screen updates

### DIFF
--- a/lib/bloc/discussion_list/discussion_list_bloc.dart
+++ b/lib/bloc/discussion_list/discussion_list_bloc.dart
@@ -24,7 +24,6 @@ class DiscussionListBloc
   Stream<DiscussionListState> mapEventToState(
     DiscussionListEvent event,
   ) async* {
-    // TODO: Format user-friendly errors
     var prevActiveList = this.state.activeDiscussions;
     var prevArchivedList = this.state.archivedDiscussions;
     var prevDeletedList = this.state.deletedDiscussions;
@@ -54,16 +53,50 @@ class DiscussionListBloc
           timestamp: DateTime.now(),
         );
       }
-    } else if (event is DiscussionListDeleteEvent) {
-      /* In order to provide a more responsive UX, we want to make the user
-         believe that the requested action happened instantly. For the same
-         reason we consume this event even if the current state is "loading". 
-         To achieve this, we yield a "loaded" state that simulates a successful
-         outcome of the requested operation. The real task is then executed as
-         an async function, which fires an "error" event to this bloc only in
-         case something goes wrong. Those "error" events are not visible outside
-         of this class scope. */
-      var transform = (e) {
+    }
+
+    /* From this point on, events related to mute/unmute/archive/restore/delete 
+       features are handled. Each one of them has been implemented in non-blocking
+       fashion. A state with a successful simulated result is emitted immediately,
+       and the operation is executed asynchronously. Once completed, the BLoC will
+       receive an async internal event that will yield another state depending on
+       the effective outcome of the operation, both in case of error or success.
+       Accordingly, every operation has a dedicated event, which is the one usable
+       by extern classes, and two internal events not visible out of this BLoC scope,
+       one for the async error case and one for the async success case.
+       
+       Since we have 3 different panels and list of discussions (active, archived,
+       and deleted), we have to consider that each operation must have restrictions
+       or certain semantics on each list. In the following implementation, this
+       has been assumed:
+       
+       Active Chats:
+         - Chats can be deleted, archived, muted, and unmuted.
+         - There is no "active flag", a chat is active if it is in the active list
+         - Chats can be in this list only if they are not archived nor deleted
+         - A chat might temporarily believe that it is not active if one of the flags
+           isDeletedLocally or isArchivedLocally is set to true in Discussion.
+         - A chat can be muted only if it is unmuted
+         - A chat can be unmuted only if it is muted
+       Archived Chats:
+         - Chats can be deleted and restored (a.k.a. re-activated)
+         - There is no "archived flag", a chat is archived if it is in the archived list
+         - Chats can be in this list only if they are nor active or deleted
+         - A chat might temporarily believe that it is not archived if one of the flags
+           isDeletedLocally or isActivatedLocally is set to true in Discussion.
+       Deleted Chats:
+         - No operation can be applied to these chats
+         - There is no "deleted flag", a chat is deleted if it is in the deleted list
+         - Chats can be in this list only if they are nor active or archived
+      
+      Part of the semantics above has been implemented by restricting the actions
+      available in the UI for each case.
+
+      This helps maintaining the local discussion lists in a consistent state. A
+      complete refresh from the backend will remove any inconsistency.
+    */
+    else if (event is DiscussionListDeleteEvent) {
+      var transform = (Discussion e) {
         if (e.id == event.discussion.id) {
           return e.copyWith(isDeletedLocally: true);
         }
@@ -85,18 +118,15 @@ class DiscussionListBloc
           if (Random().nextInt(2) == 0) {
             throw "some random error";
           }
-          this.add(_DiscussionListDeleteAsyncSuccessEvent(event.discussion));
+          var updatedDiscussion = event.discussion;
+          this.add(_DiscussionListDeleteAsyncSuccessEvent(updatedDiscussion));
         } catch (error) {
           this.add(
               _DiscussionListDeleteAsyncErrorEvent(event.discussion, error));
         }
       }();
     } else if (event is _DiscussionListDeleteAsyncErrorEvent) {
-      /* This event is asynchronously fired by this bloc internally in case 
-         something went wrong with the requested operation. We restore the
-         changes that we pretended to be successful, and yield an error state
-         accordingly. */
-      var transform = (e) {
+      var transform = (Discussion e) {
         if (e.id == event.discussion.id) {
           return e.copyWith(isDeletedLocally: false);
         }
@@ -112,10 +142,7 @@ class DiscussionListBloc
         timestamp: DateTime.now(),
       );
     } else if (event is _DiscussionListDeleteAsyncSuccessEvent) {
-      /* This event is asynchronously fired by this bloc internally in case 
-         everything has been executed flawlessly. We finalize the changes
-         requested. */
-      var transform = (e) => e.id != event.discussion.id;
+      var transform = (Discussion e) => e.id != event.discussion.id;
       var updatedActiveList = prevActiveList.where(transform).toList();
       var updatedArchivedList = prevArchivedList.where(transform).toList();
       var updatedDeletedList = [event.discussion] + prevDeletedList;
@@ -126,14 +153,247 @@ class DiscussionListBloc
         timestamp: DateTime.now(),
       );
     } else if (event is DiscussionListArchiveEvent) {
+      var transform = (Discussion e) {
+        if (e.id == event.discussion.id) {
+          return e.copyWith(isArchivedLocally: true);
+        }
+        return e;
+      };
+      var activeListWithoutElement = prevActiveList.map(transform).toList();
+      yield DiscussionListLoaded(
+        activeDiscussions: activeListWithoutElement,
+        archivedDiscussions: prevArchivedList,
+        deletedDiscussions: prevDeletedList,
+        timestamp: DateTime.now(),
+      );
+      () async {
+        try {
+          /* TODO: This is mocked behavior for UI testing. We need to hook this
+           up with repositories and real backend mutations. */
+          await Future.delayed(Duration(seconds: 2));
+          if (Random().nextInt(2) == 0) {
+            throw "some random error";
+          }
+          var updatedDiscussion = event.discussion;
+          this.add(_DiscussionListArchiveAsyncSuccessEvent(updatedDiscussion));
+        } catch (error) {
+          this.add(
+              _DiscussionListArchiveAsyncErrorEvent(event.discussion, error));
+        }
+      }();
     } else if (event is _DiscussionListArchiveAsyncErrorEvent) {
+      var transform = (Discussion e) {
+        if (e.id == event.discussion.id) {
+          return e.copyWith(isArchivedLocally: false);
+        }
+        return e;
+      };
+      var activeListWithElement = prevActiveList.map(transform).toList();
+      yield DiscussionListError(
+        activeDiscussions: activeListWithElement,
+        archivedDiscussions: prevArchivedList,
+        deletedDiscussions: prevDeletedList,
+        error: event.error,
+        timestamp: DateTime.now(),
+      );
     } else if (event is _DiscussionListArchiveAsyncSuccessEvent) {
+      var transform = (Discussion e) => e.id != event.discussion.id;
+      var updatedActiveList = prevActiveList.where(transform).toList();
+      var updatedArchivedList = [event.discussion] + prevArchivedList;
+      yield DiscussionListLoaded(
+        activeDiscussions: updatedActiveList,
+        archivedDiscussions: updatedArchivedList,
+        deletedDiscussions: prevDeletedList,
+        timestamp: DateTime.now(),
+      );
     } else if (event is DiscussionListMuteEvent) {
+      var transform = (Discussion e) {
+        if (e.id == event.discussion.id) {
+          return e.copyWith(
+            mutedUntil: DateTime.now().add(
+              Duration(seconds: event.mutedForSeconds),
+            ),
+          );
+        }
+        return e;
+      };
+      var activeEditedListElement = prevActiveList.map(transform).toList();
+      yield DiscussionListLoaded(
+        activeDiscussions: activeEditedListElement,
+        archivedDiscussions: prevArchivedList,
+        deletedDiscussions: prevDeletedList,
+        timestamp: DateTime.now(),
+      );
+      () async {
+        try {
+          /* TODO: This is mocked behavior for UI testing. We need to hook this
+           up with repositories and real backend mutations. */
+          await Future.delayed(Duration(seconds: 2));
+          if (Random().nextInt(2) == 0) {
+            throw "some random error";
+          }
+          var updatedDiscussion = event.discussion.copyWith(
+            mutedUntil: DateTime.now().add(
+              Duration(seconds: event.mutedForSeconds),
+            ),
+          );
+          this.add(_DiscussionListMuteAsyncSuccessEvent(updatedDiscussion));
+        } catch (error) {
+          this.add(_DiscussionListMuteAsyncErrorEvent(event.discussion, error));
+        }
+      }();
     } else if (event is _DiscussionListMuteAsyncErrorEvent) {
+      var transform = (Discussion e) {
+        if (e.id == event.discussion.id) {
+          return e.copyWith(
+            mutedUntil: event.discussion.mutedUntil ??
+                DateTime.now().subtract(
+                  Duration(minutes: 1),
+                ),
+          );
+        }
+        return e;
+      };
+      var activeListWithElement = prevActiveList.map(transform).toList();
+      yield DiscussionListError(
+        activeDiscussions: activeListWithElement,
+        archivedDiscussions: prevArchivedList,
+        deletedDiscussions: prevDeletedList,
+        error: event.error,
+        timestamp: DateTime.now(),
+      );
+    } else if (event is _DiscussionListMuteAsyncSuccessEvent) {
+      var updatedActiveList = prevActiveList.map((e) {
+        if (e.id == event.discussion.id) {
+          return event.discussion;
+        }
+        return e;
+      }).toList();
+      yield DiscussionListLoaded(
+        activeDiscussions: updatedActiveList,
+        archivedDiscussions: prevArchivedList,
+        deletedDiscussions: prevDeletedList,
+        timestamp: DateTime.now(),
+      );
     } else if (event is DiscussionListUnMuteEvent) {
+      var transform = (Discussion e) {
+        if (e.id == event.discussion.id) {
+          return e.copyWith(
+            mutedUntil: DateTime.now().subtract(
+              Duration(minutes: 1),
+            ),
+          );
+        }
+        return e;
+      };
+      var activeEditedListElement = prevActiveList.map(transform).toList();
+      yield DiscussionListLoaded(
+        activeDiscussions: activeEditedListElement,
+        archivedDiscussions: prevArchivedList,
+        deletedDiscussions: prevDeletedList,
+        timestamp: DateTime.now(),
+      );
+      () async {
+        try {
+          /* TODO: This is mocked behavior for UI testing. We need to hook this
+           up with repositories and real backend mutations. */
+          await Future.delayed(Duration(seconds: 2));
+          if (Random().nextInt(2) == 0) {
+            throw "some random error";
+          }
+          var updatedDiscussion = event.discussion.copyWith(
+            mutedUntil: DateTime.now().subtract(
+              Duration(minutes: 1),
+            ),
+          );
+          this.add(_DiscussionListUnMuteAsyncSuccessEvent(updatedDiscussion));
+        } catch (error) {
+          this.add(
+              _DiscussionListUnMuteAsyncErrorEvent(event.discussion, error));
+        }
+      }();
     } else if (event is _DiscussionListUnMuteAsyncErrorEvent) {
+      var transform = (Discussion e) {
+        if (e.id == event.discussion.id) {
+          return e.copyWith(mutedUntil: event.discussion.mutedUntil);
+        }
+        return e;
+      };
+      var activeListWithElement = prevActiveList.map(transform).toList();
+      yield DiscussionListError(
+        activeDiscussions: activeListWithElement,
+        archivedDiscussions: prevArchivedList,
+        deletedDiscussions: prevDeletedList,
+        error: event.error,
+        timestamp: DateTime.now(),
+      );
+    } else if (event is _DiscussionListUnMuteAsyncSuccessEvent) {
+      var updatedActiveList = prevActiveList.map((e) {
+        if (e.id == event.discussion.id) {
+          return event.discussion;
+        }
+        return e;
+      }).toList();
+      yield DiscussionListLoaded(
+        activeDiscussions: updatedActiveList,
+        archivedDiscussions: prevArchivedList,
+        deletedDiscussions: prevDeletedList,
+        timestamp: DateTime.now(),
+      );
     } else if (event is DiscussionListActivateEvent) {
+      var transform = (Discussion e) {
+        if (e.id == event.discussion.id) {
+          return e.copyWith(isActivatedLocally: true);
+        }
+        return e;
+      };
+      var archivedListWithoutElement = prevArchivedList.map(transform).toList();
+      yield DiscussionListLoaded(
+        activeDiscussions: prevActiveList,
+        archivedDiscussions: archivedListWithoutElement,
+        deletedDiscussions: prevDeletedList,
+        timestamp: DateTime.now(),
+      );
+      () async {
+        try {
+          /* TODO: This is mocked behavior for UI testing. We need to hook this
+           up with repositories and real backend mutations. */
+          await Future.delayed(Duration(seconds: 2));
+          if (Random().nextInt(2) == 0) {
+            throw "some random error";
+          }
+          var updatedDiscussion = event.discussion;
+          this.add(_DiscussionListActivateAsyncSuccessEvent(updatedDiscussion));
+        } catch (error) {
+          this.add(
+              _DiscussionListActivateAsyncErrorEvent(event.discussion, error));
+        }
+      }();
     } else if (event is _DiscussionListActivateAsyncErrorEvent) {
-    } else if (event is _DiscussionListActivateAsyncSuccessEvent) {}
+      var transform = (Discussion e) {
+        if (e.id == event.discussion.id) {
+          return e.copyWith(isActivatedLocally: false);
+        }
+        return e;
+      };
+      var archivedListWithElement = prevArchivedList.map(transform).toList();
+      yield DiscussionListError(
+        activeDiscussions: prevActiveList,
+        archivedDiscussions: archivedListWithElement,
+        deletedDiscussions: prevDeletedList,
+        error: event.error,
+        timestamp: DateTime.now(),
+      );
+    } else if (event is _DiscussionListActivateAsyncSuccessEvent) {
+      var transform = (Discussion e) => e.id != event.discussion.id;
+      var updatedArchivedList = prevArchivedList.where(transform).toList();
+      var updatedActiveList = [event.discussion] + prevActiveList;
+      yield DiscussionListLoaded(
+        activeDiscussions: updatedActiveList,
+        archivedDiscussions: updatedArchivedList,
+        deletedDiscussions: prevDeletedList,
+        timestamp: DateTime.now(),
+      );
+    }
   }
 }

--- a/lib/bloc/discussion_list/discussion_list_event.dart
+++ b/lib/bloc/discussion_list/discussion_list_event.dart
@@ -92,13 +92,14 @@ class _DiscussionListArchiveAsyncSuccessEvent extends DiscussionListEvent {
 class DiscussionListMuteEvent extends DiscussionListEvent {
   final DateTime now;
   final Discussion discussion;
+  final int mutedForSeconds;
 
-  DiscussionListMuteEvent(this.discussion)
+  DiscussionListMuteEvent(this.discussion, this.mutedForSeconds)
       : this.now = DateTime.now(),
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion];
+  List<Object> get props => [this.now, this.discussion, this.mutedForSeconds];
 }
 
 class _DiscussionListMuteAsyncErrorEvent extends DiscussionListEvent {
@@ -112,6 +113,18 @@ class _DiscussionListMuteAsyncErrorEvent extends DiscussionListEvent {
 
   @override
   List<Object> get props => [this.now, this.discussion, this.error];
+}
+
+class _DiscussionListMuteAsyncSuccessEvent extends DiscussionListEvent {
+  final DateTime now;
+  final Discussion discussion;
+
+  _DiscussionListMuteAsyncSuccessEvent(this.discussion)
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props => [this.now, this.discussion];
 }
 
 class DiscussionListUnMuteEvent extends DiscussionListEvent {
@@ -137,6 +150,18 @@ class _DiscussionListUnMuteAsyncErrorEvent extends DiscussionListEvent {
 
   @override
   List<Object> get props => [this.now, this.discussion, this.error];
+}
+
+class _DiscussionListUnMuteAsyncSuccessEvent extends DiscussionListEvent {
+  final DateTime now;
+  final Discussion discussion;
+
+  _DiscussionListUnMuteAsyncSuccessEvent(this.discussion)
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props => [this.now, this.discussion];
 }
 
 class DiscussionListActivateEvent extends DiscussionListEvent {

--- a/lib/bloc/discussion_list/discussion_list_event.dart
+++ b/lib/bloc/discussion_list/discussion_list_event.dart
@@ -55,56 +55,123 @@ class _DiscussionListDeleteAsyncSuccessEvent extends DiscussionListEvent {
 class DiscussionListArchiveEvent extends DiscussionListEvent {
   final DateTime now;
   final Discussion discussion;
-  final bool archived;
 
-  DiscussionListArchiveEvent(this.discussion, this.archived)
+  DiscussionListArchiveEvent(this.discussion)
       : this.now = DateTime.now(),
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion, this.archived];
+  List<Object> get props => [this.now, this.discussion];
 }
 
 class _DiscussionListArchiveAsyncErrorEvent extends DiscussionListEvent {
   final DateTime now;
   final Discussion discussion;
-  final bool wasArchived;
   final error;
 
-  _DiscussionListArchiveAsyncErrorEvent(
-      this.discussion, this.wasArchived, this.error)
+  _DiscussionListArchiveAsyncErrorEvent(this.discussion, this.error)
       : this.now = DateTime.now(),
         super();
 
   @override
-  List<Object> get props =>
-      [this.now, this.discussion, this.wasArchived, this.error];
+  List<Object> get props => [this.now, this.discussion, this.error];
+}
+
+class _DiscussionListArchiveAsyncSuccessEvent extends DiscussionListEvent {
+  final DateTime now;
+  final Discussion discussion;
+
+  _DiscussionListArchiveAsyncSuccessEvent(this.discussion)
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props => [this.now, this.discussion];
 }
 
 class DiscussionListMuteEvent extends DiscussionListEvent {
   final DateTime now;
   final Discussion discussion;
-  final bool muted;
 
-  DiscussionListMuteEvent(this.discussion, this.muted)
+  DiscussionListMuteEvent(this.discussion)
       : this.now = DateTime.now(),
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion, this.muted];
+  List<Object> get props => [this.now, this.discussion];
 }
 
 class _DiscussionListMuteAsyncErrorEvent extends DiscussionListEvent {
   final DateTime now;
   final Discussion discussion;
-  final bool wasMuted;
   final error;
 
-  _DiscussionListMuteAsyncErrorEvent(this.discussion, this.wasMuted, this.error)
+  _DiscussionListMuteAsyncErrorEvent(this.discussion, this.error)
       : this.now = DateTime.now(),
         super();
 
   @override
-  List<Object> get props =>
-      [this.now, this.discussion, this.wasMuted, this.error];
+  List<Object> get props => [this.now, this.discussion, this.error];
+}
+
+class DiscussionListUnMuteEvent extends DiscussionListEvent {
+  final DateTime now;
+  final Discussion discussion;
+
+  DiscussionListUnMuteEvent(this.discussion)
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props => [this.now, this.discussion];
+}
+
+class _DiscussionListUnMuteAsyncErrorEvent extends DiscussionListEvent {
+  final DateTime now;
+  final Discussion discussion;
+  final error;
+
+  _DiscussionListUnMuteAsyncErrorEvent(this.discussion, this.error)
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props => [this.now, this.discussion, this.error];
+}
+
+class DiscussionListActivateEvent extends DiscussionListEvent {
+  final DateTime now;
+  final Discussion discussion;
+
+  DiscussionListActivateEvent(this.discussion)
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props => [this.now, this.discussion];
+}
+
+class _DiscussionListActivateAsyncErrorEvent extends DiscussionListEvent {
+  final DateTime now;
+  final Discussion discussion;
+  final error;
+
+  _DiscussionListActivateAsyncErrorEvent(this.discussion, this.error)
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props => [this.now, this.discussion, this.error];
+}
+
+class _DiscussionListActivateAsyncSuccessEvent extends DiscussionListEvent {
+  final DateTime now;
+  final Discussion discussion;
+
+  _DiscussionListActivateAsyncSuccessEvent(this.discussion)
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props => [this.now, this.discussion];
 }

--- a/lib/bloc/discussion_list/discussion_list_event.dart
+++ b/lib/bloc/discussion_list/discussion_list_event.dart
@@ -24,7 +24,7 @@ class DiscussionListDeleteEvent extends DiscussionListEvent {
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion];
+  List<Object> get props => [this.now, this.discussion.id];
 }
 
 class _DiscussionListDeleteAsyncErrorEvent extends DiscussionListEvent {
@@ -37,7 +37,7 @@ class _DiscussionListDeleteAsyncErrorEvent extends DiscussionListEvent {
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion, this.error];
+  List<Object> get props => [this.now, this.discussion.id, this.error];
 }
 
 class _DiscussionListDeleteAsyncSuccessEvent extends DiscussionListEvent {
@@ -49,7 +49,7 @@ class _DiscussionListDeleteAsyncSuccessEvent extends DiscussionListEvent {
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion];
+  List<Object> get props => [this.now, this.discussion.id];
 }
 
 class DiscussionListArchiveEvent extends DiscussionListEvent {
@@ -61,7 +61,7 @@ class DiscussionListArchiveEvent extends DiscussionListEvent {
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion];
+  List<Object> get props => [this.now, this.discussion.id];
 }
 
 class _DiscussionListArchiveAsyncErrorEvent extends DiscussionListEvent {
@@ -74,7 +74,7 @@ class _DiscussionListArchiveAsyncErrorEvent extends DiscussionListEvent {
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion, this.error];
+  List<Object> get props => [this.now, this.discussion.id, this.error];
 }
 
 class _DiscussionListArchiveAsyncSuccessEvent extends DiscussionListEvent {
@@ -86,7 +86,7 @@ class _DiscussionListArchiveAsyncSuccessEvent extends DiscussionListEvent {
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion];
+  List<Object> get props => [this.now, this.discussion.id];
 }
 
 class DiscussionListMuteEvent extends DiscussionListEvent {
@@ -99,7 +99,8 @@ class DiscussionListMuteEvent extends DiscussionListEvent {
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion, this.mutedForSeconds];
+  List<Object> get props =>
+      [this.now, this.discussion.id, this.mutedForSeconds];
 }
 
 class _DiscussionListMuteAsyncErrorEvent extends DiscussionListEvent {
@@ -112,7 +113,7 @@ class _DiscussionListMuteAsyncErrorEvent extends DiscussionListEvent {
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion, this.error];
+  List<Object> get props => [this.now, this.discussion.id, this.error];
 }
 
 class _DiscussionListMuteAsyncSuccessEvent extends DiscussionListEvent {
@@ -124,7 +125,7 @@ class _DiscussionListMuteAsyncSuccessEvent extends DiscussionListEvent {
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion];
+  List<Object> get props => [this.now, this.discussion.id];
 }
 
 class DiscussionListUnMuteEvent extends DiscussionListEvent {
@@ -136,7 +137,7 @@ class DiscussionListUnMuteEvent extends DiscussionListEvent {
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion];
+  List<Object> get props => [this.now, this.discussion.id];
 }
 
 class _DiscussionListUnMuteAsyncErrorEvent extends DiscussionListEvent {
@@ -149,7 +150,7 @@ class _DiscussionListUnMuteAsyncErrorEvent extends DiscussionListEvent {
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion, this.error];
+  List<Object> get props => [this.now, this.discussion.id, this.error];
 }
 
 class _DiscussionListUnMuteAsyncSuccessEvent extends DiscussionListEvent {
@@ -161,7 +162,7 @@ class _DiscussionListUnMuteAsyncSuccessEvent extends DiscussionListEvent {
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion];
+  List<Object> get props => [this.now, this.discussion.id];
 }
 
 class DiscussionListActivateEvent extends DiscussionListEvent {
@@ -173,7 +174,7 @@ class DiscussionListActivateEvent extends DiscussionListEvent {
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion];
+  List<Object> get props => [this.now, this.discussion.id];
 }
 
 class _DiscussionListActivateAsyncErrorEvent extends DiscussionListEvent {
@@ -186,7 +187,7 @@ class _DiscussionListActivateAsyncErrorEvent extends DiscussionListEvent {
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion, this.error];
+  List<Object> get props => [this.now, this.discussion.id, this.error];
 }
 
 class _DiscussionListActivateAsyncSuccessEvent extends DiscussionListEvent {
@@ -198,5 +199,5 @@ class _DiscussionListActivateAsyncSuccessEvent extends DiscussionListEvent {
         super();
 
   @override
-  List<Object> get props => [this.now, this.discussion];
+  List<Object> get props => [this.now, this.discussion.id];
 }

--- a/lib/bloc/discussion_list/discussion_list_state.dart
+++ b/lib/bloc/discussion_list/discussion_list_state.dart
@@ -9,9 +9,9 @@ abstract class DiscussionListState extends Equatable {
 
   @override
   List<Object> get props => [
-        activeDiscussions,
-        archivedDiscussions,
-        deletedDiscussions,
+        activeDiscussions.map((d) => d.id).toList(),
+        archivedDiscussions.map((d) => d.id).toList(),
+        deletedDiscussions.map((d) => d.id).toList(),
       ];
 }
 
@@ -38,9 +38,9 @@ class DiscussionListError extends DiscussionListHasTimestamp {
 
   @override
   List<Object> get props => [
-        this.activeDiscussions,
-        this.archivedDiscussions,
-        this.deletedDiscussions,
+        this.activeDiscussions.map((d) => d.id).toList(),
+        this.archivedDiscussions.map((d) => d.id).toList(),
+        this.deletedDiscussions.map((d) => d.id).toList(),
         this.error,
         this.timestamp,
       ];
@@ -61,9 +61,9 @@ class DiscussionListLoading extends DiscussionListHasTimestamp {
 
   @override
   List<Object> get props => [
-        this.activeDiscussions,
-        this.archivedDiscussions,
-        this.deletedDiscussions,
+        this.activeDiscussions.map((d) => d.id).toList(),
+        this.archivedDiscussions.map((d) => d.id).toList(),
+        this.deletedDiscussions.map((d) => d.id).toList(),
         this.timestamp,
       ];
 }
@@ -83,9 +83,9 @@ class DiscussionListLoaded extends DiscussionListHasTimestamp {
 
   @override
   List<Object> get props => [
-        this.activeDiscussions,
-        this.archivedDiscussions,
-        this.deletedDiscussions,
+        this.activeDiscussions.map((d) => d.id).toList(),
+        this.archivedDiscussions.map((d) => d.id).toList(),
+        this.deletedDiscussions.map((d) => d.id).toList(),
         this.timestamp,
       ];
 }

--- a/lib/bloc/discussion_list/discussion_list_state.dart
+++ b/lib/bloc/discussion_list/discussion_list_state.dart
@@ -1,56 +1,91 @@
 part of 'discussion_list_bloc.dart';
 
 abstract class DiscussionListState extends Equatable {
-  final List<Discussion> discussionList = [];
+  final List<Discussion> activeDiscussions = [];
+  final List<Discussion> archivedDiscussions = [];
+  final List<Discussion> deletedDiscussions = [];
+
   DiscussionListState();
+
+  @override
+  List<Object> get props => [
+        activeDiscussions,
+        archivedDiscussions,
+        deletedDiscussions,
+      ];
 }
 
 abstract class DiscussionListHasTimestamp extends DiscussionListState {
   DateTime get timestamp;
 }
 
-class DiscussionListInitial extends DiscussionListState {
-  @override
-  List<Object> get props => [];
-}
+class DiscussionListInitial extends DiscussionListState {}
 
 class DiscussionListError extends DiscussionListHasTimestamp {
-  final List<Discussion> discussionList;
+  final List<Discussion> activeDiscussions;
+  final List<Discussion> archivedDiscussions;
+  final List<Discussion> deletedDiscussions;
   final error;
   final DateTime timestamp;
 
   DiscussionListError({
-    @required this.discussionList,
+    @required this.activeDiscussions,
+    @required this.archivedDiscussions,
+    @required this.deletedDiscussions,
     @required this.error,
     @required this.timestamp,
   }) : super();
 
   @override
-  List<Object> get props => [this.discussionList, this.error, this.timestamp];
+  List<Object> get props => [
+        this.activeDiscussions,
+        this.archivedDiscussions,
+        this.deletedDiscussions,
+        this.error,
+        this.timestamp,
+      ];
 }
 
 class DiscussionListLoading extends DiscussionListHasTimestamp {
-  final List<Discussion> discussionList;
+  final List<Discussion> activeDiscussions;
+  final List<Discussion> archivedDiscussions;
+  final List<Discussion> deletedDiscussions;
   final DateTime timestamp;
 
   DiscussionListLoading({
-    @required this.discussionList,
+    @required this.activeDiscussions,
+    @required this.archivedDiscussions,
+    @required this.deletedDiscussions,
     @required this.timestamp,
   }) : super();
 
   @override
-  List<Object> get props => [this.discussionList, this.timestamp];
+  List<Object> get props => [
+        this.activeDiscussions,
+        this.archivedDiscussions,
+        this.deletedDiscussions,
+        this.timestamp,
+      ];
 }
 
 class DiscussionListLoaded extends DiscussionListHasTimestamp {
-  final List<Discussion> discussionList;
+  final List<Discussion> activeDiscussions;
+  final List<Discussion> archivedDiscussions;
+  final List<Discussion> deletedDiscussions;
   final DateTime timestamp;
 
   DiscussionListLoaded({
-    @required this.discussionList,
+    @required this.activeDiscussions,
+    @required this.archivedDiscussions,
+    @required this.deletedDiscussions,
     @required this.timestamp,
   }) : super();
 
   @override
-  List<Object> get props => [this.discussionList, this.timestamp];
+  List<Object> get props => [
+        this.activeDiscussions,
+        this.archivedDiscussions,
+        this.deletedDiscussions,
+        this.timestamp,
+      ];
 }

--- a/lib/chatham_app.dart
+++ b/lib/chatham_app.dart
@@ -10,6 +10,7 @@ import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
 import 'package:delphis_app/data/repository/discussion.dart';
 import 'package:delphis_app/data/repository/media.dart';
 import 'package:delphis_app/data/repository/user.dart';
+import 'package:delphis_app/notifiers/home_page_tab.dart';
 import 'package:delphis_app/screens/auth/base/sign_in.dart';
 import 'package:delphis_app/screens/discussion/naming_discussion.dart';
 import 'package:delphis_app/screens/superpowers/superpowers_arguments.dart';
@@ -26,6 +27,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_segment/flutter_segment.dart';
 import 'package:page_transition/page_transition.dart';
+import 'package:provider/provider.dart';
 import 'package:uni_links/uni_links.dart';
 
 import 'bloc/auth/auth_bloc.dart';
@@ -219,8 +221,8 @@ class ChathamAppState extends State<ChathamApp>
               BlocListener<DiscussionListBloc, DiscussionListState>(
                   listener: (context, state) {
                 if (state is DiscussionListLoaded) {
-                  BlocProvider.of<MentionBloc>(context).add(
-                      AddMentionDataEvent(discussions: state.discussionList));
+                  BlocProvider.of<MentionBloc>(context).add(AddMentionDataEvent(
+                      discussions: state.activeDiscussions));
                 }
               }),
               BlocListener<LinkBloc, LinkState>(listener: (context, state) {
@@ -314,12 +316,16 @@ class ChathamAppState extends State<ChathamApp>
                               );
                             }
                           },
-                          child: HomePageScreen(
-                            key: this._homePageKey,
-                            discussionRepository:
-                                RepositoryProvider.of<DiscussionRepository>(
-                                    context),
-                            routeObserver: this._routeObserver,
+                          child: ChangeNotifierProvider<HomePageTabNotifier>(
+                            create: (context) =>
+                                HomePageTabNotifier(HomePageTab.ACTIVE),
+                            child: HomePageScreen(
+                              key: this._homePageKey,
+                              discussionRepository:
+                                  RepositoryProvider.of<DiscussionRepository>(
+                                      context),
+                              routeObserver: this._routeObserver,
+                            ),
                           ),
                         ),
                       ),

--- a/lib/data/repository/discussion.dart
+++ b/lib/data/repository/discussion.dart
@@ -512,12 +512,19 @@ class Discussion extends Equatable implements Entity {
   final List<HistoricalString> titleHistory;
   final List<HistoricalString> descriptionHistory;
   final DiscussionJoinabilitySetting discussionJoinability;
+  final DateTime mutedUntil;
 
   @JsonAnnotation.JsonKey(ignore: true)
   List<Post> postsCache;
 
   @JsonAnnotation.JsonKey(ignore: true)
+  bool isActivatedLocally;
+
+  @JsonAnnotation.JsonKey(ignore: true)
   bool isDeletedLocally;
+
+  @JsonAnnotation.JsonKey(ignore: true)
+  bool isArchivedLocally;
 
   @override
   List<Object> get props => [
@@ -536,7 +543,10 @@ class Discussion extends Equatable implements Entity {
         titleHistory,
         descriptionHistory,
         discussionJoinability,
+        mutedUntil,
         isDeletedLocally,
+        isActivatedLocally,
+        isArchivedLocally,
       ];
 
   Discussion({
@@ -556,61 +566,27 @@ class Discussion extends Equatable implements Entity {
     this.titleHistory,
     this.descriptionHistory,
     this.discussionJoinability,
+    this.mutedUntil,
     postsCache,
     this.isDeletedLocally = false,
+    this.isActivatedLocally = false,
+    this.isArchivedLocally = false,
   }) : this.postsCache =
             postsCache ?? (postsConnection?.asPostList() ?? List());
 
-  factory Discussion.fromJson(Map<String, dynamic> json) =>
-      _$DiscussionFromJson(json);
+  factory Discussion.fromJson(Map<String, dynamic> json) {
+    var parsed = _$DiscussionFromJson(json);
+    if (json['mutedForSeconds'] != null) {
+      var seconds = json['mutedForSeconds'] as int;
+      return parsed.copyWith(
+        mutedUntil: DateTime.now().add(Duration(seconds: seconds)),
+      );
+    }
+    return parsed;
+  }
 
   Map<String, dynamic> toJSON() {
     return _$DiscussionToJson(this);
-  }
-
-  Discussion copyWith({
-    String id,
-    Moderator moderator,
-    AnonymityType anonymityType,
-    PostsConnection postsConnection,
-    List<Participant> participants,
-    String title,
-    String createdAt,
-    String updatedAt,
-    Participant meParticipant,
-    List<Participant> meAvailableParticipants,
-    String iconURL,
-    DiscussionLinkAccess discussionLinksAccess,
-    String description,
-    List<HistoricalString> titleHistory,
-    List<HistoricalString> descriptionHistory,
-    DiscussionJoinabilitySetting discussionJoinability,
-    List<Post> postsCache,
-    bool isDeletedLocally,
-  }) {
-    return Discussion(
-      id: id ?? this.id,
-      moderator: moderator ?? this.moderator,
-      anonymityType: anonymityType ?? this.anonymityType,
-      postsConnection: postsConnection ?? this.postsConnection,
-      participants: participants ?? this.participants,
-      title: title ?? this.title,
-      createdAt: createdAt ?? this.createdAt,
-      updatedAt: updatedAt ?? this.updatedAt,
-      meParticipant: meParticipant ?? this.meParticipant,
-      meAvailableParticipants:
-          meAvailableParticipants ?? this.meAvailableParticipants,
-      iconURL: iconURL ?? this.iconURL,
-      discussionLinksAccess:
-          discussionLinksAccess ?? this.discussionLinksAccess,
-      description: description ?? this.description,
-      titleHistory: titleHistory ?? this.titleHistory,
-      descriptionHistory: descriptionHistory ?? this.descriptionHistory,
-      discussionJoinability:
-          discussionJoinability ?? this.discussionJoinability,
-      postsCache: postsCache ?? this.postsCache,
-      isDeletedLocally: isDeletedLocally ?? this.isDeletedLocally,
-    );
   }
 
   void addLocalPost(LocalPost post) {
@@ -658,6 +634,61 @@ class Discussion extends Equatable implements Entity {
             ?.map((e) => e?.userProfile?.id)
             ?.contains(this.moderator?.userProfile?.id) ??
         false;
+  }
+
+  bool get isMuted {
+    return mutedUntil != null && mutedUntil.isAfter(DateTime.now());
+  }
+
+  Discussion copyWith({
+    String id,
+    Moderator moderator,
+    AnonymityType anonymityType,
+    PostsConnection postsConnection,
+    List<Participant> participants,
+    String title,
+    String createdAt,
+    String updatedAt,
+    Participant meParticipant,
+    List<Participant> meAvailableParticipants,
+    String iconURL,
+    DiscussionLinkAccess discussionLinksAccess,
+    String description,
+    List<HistoricalString> titleHistory,
+    List<HistoricalString> descriptionHistory,
+    DiscussionJoinabilitySetting discussionJoinability,
+    DateTime mutedUntil,
+    List<Post> postsCache,
+    bool isActivatedLocally,
+    bool isDeletedLocally,
+    bool isArchivedLocally,
+  }) {
+    return Discussion(
+      id: id ?? this.id,
+      moderator: moderator ?? this.moderator,
+      anonymityType: anonymityType ?? this.anonymityType,
+      postsConnection: postsConnection ?? this.postsConnection,
+      participants: participants ?? this.participants,
+      title: title ?? this.title,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      meParticipant: meParticipant ?? this.meParticipant,
+      meAvailableParticipants:
+          meAvailableParticipants ?? this.meAvailableParticipants,
+      iconURL: iconURL ?? this.iconURL,
+      discussionLinksAccess:
+          discussionLinksAccess ?? this.discussionLinksAccess,
+      description: description ?? this.description,
+      titleHistory: titleHistory ?? this.titleHistory,
+      descriptionHistory: descriptionHistory ?? this.descriptionHistory,
+      discussionJoinability:
+          discussionJoinability ?? this.discussionJoinability,
+      mutedUntil: mutedUntil ?? this.mutedUntil,
+      postsCache: postsCache ?? this.postsCache,
+      isActivatedLocally: isActivatedLocally ?? this.isActivatedLocally,
+      isDeletedLocally: isDeletedLocally ?? this.isDeletedLocally,
+      isArchivedLocally: isArchivedLocally ?? this.isArchivedLocally,
+    );
   }
 }
 

--- a/lib/design/text_theme.dart
+++ b/lib/design/text_theme.dart
@@ -236,6 +236,11 @@ class TextThemes {
     color: Color.fromRGBO(23, 23, 28, 1.0),
     letterSpacing: -0.22,
   );
+  static final homeScreenActionBarItem = TextStyle(
+    fontSize: 14.0,
+    fontWeight: FontWeight.w300,
+    color: Color.fromRGBO(255, 255, 255, 1.0),
+  );
 
   static final emojiPickerText = TextStyle(
     fontSize: 11.0,

--- a/lib/notifiers/home_page_tab.dart
+++ b/lib/notifiers/home_page_tab.dart
@@ -1,0 +1,15 @@
+import 'package:delphis_app/screens/home_page/home_page.dart';
+import 'package:flutter/material.dart';
+
+class HomePageTabNotifier extends ChangeNotifier {
+  HomePageTab _current;
+
+  HomePageTabNotifier(this._current);
+
+  HomePageTab get value => _current;
+
+  set value(HomePageTab value) {
+    _current = value;
+    notifyListeners();
+  }
+}

--- a/lib/screens/discussion/header_options_button.dart
+++ b/lib/screens/discussion/header_options_button.dart
@@ -1,4 +1,7 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 enum HeaderOption { logout }
 
@@ -18,11 +21,16 @@ class HeaderOptionsButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PopupMenuButton<HeaderOption>(
+      elevation: 0,
+      color: Color.fromRGBO(34, 35, 40, 1.0),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(30),
+      ),
       child: Container(
         width: this.diameter,
         height: this.diameter,
-        decoration: BoxDecoration(
-            shape: BoxShape.circle, color: Color.fromRGBO(34, 35, 40, 0.0)),
+        decoration:
+            BoxDecoration(shape: BoxShape.circle, color: Colors.transparent),
         alignment: Alignment.center,
         child: Icon(
           this.isVertical ? Icons.more_vert : Icons.more_horiz,
@@ -33,9 +41,18 @@ class HeaderOptionsButton extends StatelessWidget {
       ),
       onSelected: this.onPressed,
       itemBuilder: (BuildContext context) => <PopupMenuEntry<HeaderOption>>[
-        const PopupMenuItem<HeaderOption>(
+        PopupMenuItem<HeaderOption>(
           value: HeaderOption.logout,
-          child: Text('Logout'),
+          child: Row(
+            children: <Widget>[
+              Text(
+                Intl.message('Logout'),
+              ),
+              Expanded(
+                child: Icon(Icons.exit_to_app),
+              ),
+            ],
+          ),
         ),
       ],
     );

--- a/lib/screens/home_page/chats/chats_list.dart
+++ b/lib/screens/home_page/chats/chats_list.dart
@@ -2,6 +2,8 @@ import 'package:delphis_app/bloc/discussion/discussion_bloc.dart';
 import 'package:delphis_app/bloc/discussion_list/discussion_list_bloc.dart';
 import 'package:delphis_app/data/repository/user.dart';
 import 'package:delphis_app/design/sizes.dart';
+import 'package:delphis_app/design/text_theme.dart';
+import 'package:delphis_app/notifiers/home_page_tab.dart';
 import 'package:delphis_app/screens/home_page/chats/single_chat.dart';
 import 'package:delphis_app/screens/home_page/home_page.dart';
 import 'package:flutter/cupertino.dart';
@@ -9,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
 
 class ChatsList extends StatelessWidget {
@@ -16,7 +19,9 @@ class ChatsList extends StatelessWidget {
   final DiscussionCallback onJoinDiscussionPressed;
   final DiscussionCallback onDeleteDiscussionPressed;
   final DiscussionCallback onArchiveDiscussionPressed;
+  final DiscussionCallback onActivateDiscussionPressed;
   final DiscussionCallback onMuteDiscussionPressed;
+  final DiscussionCallback onUnMuteDiscussionPressed;
   final DiscussionCallback onDiscussionPressed;
   final RefreshController refreshController;
   final User currentUser;
@@ -28,7 +33,9 @@ class ChatsList extends StatelessWidget {
     @required this.onJoinDiscussionPressed,
     @required this.onDeleteDiscussionPressed,
     @required this.onArchiveDiscussionPressed,
+    @required this.onActivateDiscussionPressed,
     @required this.onMuteDiscussionPressed,
+    @required this.onUnMuteDiscussionPressed,
     @required this.onDiscussionPressed,
     @required this.currentUser,
     this.durationBeforeAutoRefresh,
@@ -52,112 +59,198 @@ class ChatsList extends StatelessWidget {
           return Container();
         }
 
-        if (state is DiscussionListLoading &&
-            state.discussionList.length == 0) {
-          return Center(child: CircularProgressIndicator());
-        }
+        /* Select the current open list */
+        return Consumer<HomePageTabNotifier>(
+          builder: (context, currentTab, _) {
+            var showedDiscussions = [];
+            switch (currentTab.value) {
+              case HomePageTab.ARCHIVED:
+                showedDiscussions = state.archivedDiscussions;
+                break;
+              case HomePageTab.ACTIVE:
+                showedDiscussions = state.activeDiscussions;
+                break;
+              case HomePageTab.TRASHED:
+                showedDiscussions = state.deletedDiscussions;
+                break;
+            }
 
-        var errorWidget = Container();
-        if (state is DiscussionListError) {
-          errorWidget = Container(
-            color: Colors.red,
-            padding: EdgeInsets.symmetric(
-                vertical: SpacingValues.medium,
-                horizontal: SpacingValues.large),
-            child: Text(
-              state.error.toString(),
-              textAlign: TextAlign.center,
-            ),
-          );
-        }
-
-        /* Autorefresh if discussion list is outdated */
-        var duration = this.durationBeforeAutoRefresh ?? Duration(minutes: 20);
-        if (state is DiscussionListHasTimestamp &&
-            DateTime.now().difference(state.timestamp) > duration) {
-          BlocProvider.of<DiscussionListBloc>(context)
-              .add(DiscussionListFetchEvent());
-        }
-
-        return SmartRefresher(
-          enablePullDown: true,
-          enablePullUp: false,
-          header: CustomHeader(
-            builder: (context, status) {
-              Widget body;
-              if (status == RefreshStatus.idle) {
-                body = CupertinoActivityIndicator();
-              } else if (status == RefreshStatus.refreshing) {
-                body = CupertinoActivityIndicator();
-              } else if (status == RefreshStatus.failed) {
-                body = Text(Intl.message("Refresh failed..."));
-              } else if (status == RefreshStatus.canRefresh) {
-                body = CupertinoActivityIndicator();
-              } else {
-                body = Container(width: 0, height: 0);
-              }
-              return Container(
-                height: 55.0,
-                child: Center(
-                  child: body,
+            if (state is DiscussionListLoading &&
+                showedDiscussions.length == 0) {
+              return Center(child: CircularProgressIndicator());
+            } else if (showedDiscussions.length == 0) {
+              return Center(
+                child: Container(
+                  margin: EdgeInsets.all(SpacingValues.large),
+                  child: getEmptyLisWidget(currentTab.value),
                 ),
               );
-            },
-          ),
-          footer: Container(),
-          controller: this.refreshController,
-          onRefresh: () async {
-            BlocProvider.of<DiscussionListBloc>(context)
-                .add(DiscussionListFetchEvent());
-          },
-          onLoading: () {},
-          child: ListView.builder(
-            padding: EdgeInsets.zero,
-            key: Key('discussion-list-view'),
-            scrollDirection: Axis.vertical,
-            shrinkWrap: true,
-            itemCount: state.discussionList.length + 1,
-            itemBuilder: (context, index) {
-              if (index == 0) return errorWidget;
-              index--;
-              var discussionElem = state.discussionList[index];
-              return BlocBuilder<DiscussionBloc, DiscussionState>(
-                builder: (context, discussionState) {
-                  if (discussionState is DiscussionLoadedState &&
-                      discussionState.getDiscussion() != null) {
-                    if (discussionState.getDiscussion().id ==
-                        discussionElem.id) {
-                      state.discussionList[index] =
-                          discussionState.getDiscussion();
-                      discussionElem = state.discussionList[index];
-                    }
+            }
+
+            var errorWidget = Container();
+            if (state is DiscussionListError) {
+              errorWidget = Container(
+                color: Colors.red,
+                padding: EdgeInsets.symmetric(
+                    vertical: SpacingValues.medium,
+                    horizontal: SpacingValues.large),
+                child: Text(
+                  state.error.toString(),
+                  textAlign: TextAlign.center,
+                ),
+              );
+            }
+
+            /* Autorefresh if discussion list is outdated */
+            var duration =
+                this.durationBeforeAutoRefresh ?? Duration(minutes: 20);
+            if (state is DiscussionListHasTimestamp &&
+                DateTime.now().difference(state.timestamp) > duration) {
+              BlocProvider.of<DiscussionListBloc>(context)
+                  .add(DiscussionListFetchEvent());
+            }
+
+            return SmartRefresher(
+              enablePullDown: true,
+              enablePullUp: false,
+              header: CustomHeader(
+                builder: (context, status) {
+                  Widget body;
+                  if (status == RefreshStatus.idle) {
+                    body = CupertinoActivityIndicator();
+                  } else if (status == RefreshStatus.refreshing) {
+                    body = CupertinoActivityIndicator();
+                  } else if (status == RefreshStatus.failed) {
+                    body = Text(Intl.message("Refresh failed..."));
+                  } else if (status == RefreshStatus.canRefresh) {
+                    body = CupertinoActivityIndicator();
+                  } else {
+                    body = Container(width: 0, height: 0);
                   }
-                  return SingleChat(
-                    discussion: discussionElem,
-                    canJoinDiscussions: currentUser?.isTwitterAuth ?? false,
-                    slidableController: this.slidableController,
-                    onJoinPressed: () {
-                      this.onJoinDiscussionPressed(discussionElem);
-                    },
-                    onDeletePressed: () {
-                      this.onDeleteDiscussionPressed(discussionElem);
-                    },
-                    onPressed: () {
-                      this.onDiscussionPressed(discussionElem);
-                    },
-                    onArchivePressed: () {
-                      this.onArchiveDiscussionPressed(discussionElem);
-                    },
-                    onMutePressed: () {
-                      this.onMuteDiscussionPressed(discussionElem);
+                  return Container(
+                    height: 55.0,
+                    child: Center(
+                      child: body,
+                    ),
+                  );
+                },
+              ),
+              footer: Container(),
+              controller: this.refreshController,
+              onRefresh: () async {
+                BlocProvider.of<DiscussionListBloc>(context)
+                    .add(DiscussionListFetchEvent());
+              },
+              onLoading: () {},
+              child: ListView.builder(
+                padding: EdgeInsets.zero,
+                key: Key('discussion-list-view'),
+                scrollDirection: Axis.vertical,
+                shrinkWrap: true,
+                itemCount: showedDiscussions.length + 1,
+                itemBuilder: (context, index) {
+                  if (index == 0) return errorWidget;
+                  index--;
+                  var discussionElem = showedDiscussions[index];
+                  return BlocBuilder<DiscussionBloc, DiscussionState>(
+                    builder: (context, discussionState) {
+                      if (discussionState is DiscussionLoadedState &&
+                          discussionState.getDiscussion() != null) {
+                        if (discussionState.getDiscussion().id ==
+                            discussionElem.id) {
+                          showedDiscussions[index] =
+                              discussionState.getDiscussion();
+                          discussionElem = showedDiscussions[index];
+                        }
+                      }
+                      return SingleChat(
+                        discussion: discussionElem,
+                        canJoinDiscussions: currentUser?.isTwitterAuth ?? false,
+                        slidableController: this.slidableController,
+                        onJoinPressed: () {
+                          this.onJoinDiscussionPressed(discussionElem);
+                        },
+                        onPressed: () {
+                          this.onDiscussionPressed(discussionElem);
+                        },
+                        onDeletePressed: () {
+                          this.onDeleteDiscussionPressed(discussionElem);
+                        },
+                        onArchivePressed: () {
+                          this.onArchiveDiscussionPressed(discussionElem);
+                        },
+                        onActivatePressed: () {
+                          this.onActivateDiscussionPressed(discussionElem);
+                        },
+                        onMutePressed: () {
+                          this.onMuteDiscussionPressed(discussionElem);
+                        },
+                        onUnMutePressed: () {
+                          this.onUnMuteDiscussionPressed(discussionElem);
+                        },
+                      );
                     },
                   );
                 },
-              );
-            },
-          ),
+              ),
+            );
+          },
         );
       }),
     );
+  }
+
+  Widget getEmptyLisWidget(HomePageTab value) {
+    switch (value) {
+      case HomePageTab.ACTIVE:
+        // TODO: create ad-hoc widget for checking twitter auth and welcome user
+        return Text(
+          Intl.message("You have no active chats."),
+          style: TextThemes.onboardHeading,
+          textAlign: TextAlign.center,
+        );
+      case HomePageTab.ARCHIVED:
+        return Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Text(
+              Intl.message("There are no archived chats."),
+              style: TextThemes.onboardHeading,
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(
+              height: SpacingValues.mediumLarge,
+            ),
+            Text(
+              Intl.message(
+                  "When a chat is archived you maintain your participant status, but you will not receive any notifications for new updates."),
+              textAlign: TextAlign.center,
+              style: TextThemes.onboardBody,
+            ),
+          ],
+        );
+
+      case HomePageTab.TRASHED:
+        return Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Text(
+              Intl.message("You haven't deleted any chat yet."),
+              style: TextThemes.onboardHeading,
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(
+              height: SpacingValues.mediumLarge,
+            ),
+            Text(
+              Intl.message(
+                  "You can delete a chat when you don't wish to participate in it anymore.\nDeleted chats will disappear from your feed after 90 days from the deletion."),
+              textAlign: TextAlign.center,
+              style: TextThemes.onboardBody,
+            ),
+          ],
+        );
+    }
+    return Container();
   }
 }

--- a/lib/screens/home_page/chats/chats_list.dart
+++ b/lib/screens/home_page/chats/chats_list.dart
@@ -6,6 +6,7 @@ import 'package:delphis_app/design/text_theme.dart';
 import 'package:delphis_app/notifiers/home_page_tab.dart';
 import 'package:delphis_app/screens/home_page/chats/single_chat.dart';
 import 'package:delphis_app/screens/home_page/home_page.dart';
+import 'package:delphis_app/widgets/animated_size_container/animated_size_container.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -142,39 +143,43 @@ class ChatsList extends StatelessWidget {
                     .add(DiscussionListFetchEvent());
               },
               onLoading: () {},
-              child: ListView.builder(
-                padding: EdgeInsets.zero,
-                scrollDirection: Axis.vertical,
-                shrinkWrap: true,
-                itemCount: showedDiscussions.length + 1,
-                itemBuilder: (context, index) {
-                  if (index == 0) return errorWidget;
-                  index--;
-                  var discussionElem = showedDiscussions[index];
-                  return SingleChat(
-                    discussion: discussionElem,
-                    canJoinDiscussions: currentUser?.isTwitterAuth ?? false,
-                    slidableController: this.slidableController,
-                    onJoinPressed: () {
-                      this.onJoinDiscussionPressed(discussionElem);
-                    },
-                    onPressed: () {
-                      this.onDiscussionPressed(discussionElem);
-                    },
-                    onDeletePressed: () {
-                      this.onDeleteDiscussionPressed(discussionElem);
-                    },
-                    onArchivePressed: () {
-                      this.onArchiveDiscussionPressed(discussionElem);
-                    },
-                    onActivatePressed: () {
-                      this.onActivateDiscussionPressed(discussionElem);
-                    },
-                    onMutePressed: () {
-                      this.onMuteDiscussionPressed(discussionElem);
-                    },
-                    onUnMutePressed: () {
-                      this.onUnMuteDiscussionPressed(discussionElem);
+              child: AnimatedSizeContainer(
+                builder: (context) {
+                  return ListView.builder(
+                    padding: EdgeInsets.zero,
+                    scrollDirection: Axis.vertical,
+                    shrinkWrap: true,
+                    itemCount: showedDiscussions.length + 1,
+                    itemBuilder: (context, index) {
+                      if (index == 0) return errorWidget;
+                      index--;
+                      var discussionElem = showedDiscussions[index];
+                      return SingleChat(
+                        discussion: discussionElem,
+                        canJoinDiscussions: currentUser?.isTwitterAuth ?? false,
+                        slidableController: this.slidableController,
+                        onJoinPressed: () {
+                          this.onJoinDiscussionPressed(discussionElem);
+                        },
+                        onPressed: () {
+                          this.onDiscussionPressed(discussionElem);
+                        },
+                        onDeletePressed: () {
+                          this.onDeleteDiscussionPressed(discussionElem);
+                        },
+                        onArchivePressed: () {
+                          this.onArchiveDiscussionPressed(discussionElem);
+                        },
+                        onActivatePressed: () {
+                          this.onActivateDiscussionPressed(discussionElem);
+                        },
+                        onMutePressed: () {
+                          this.onMuteDiscussionPressed(discussionElem);
+                        },
+                        onUnMutePressed: () {
+                          this.onUnMuteDiscussionPressed(discussionElem);
+                        },
+                      );
                     },
                   );
                 },

--- a/lib/screens/home_page/chats/chats_list.dart
+++ b/lib/screens/home_page/chats/chats_list.dart
@@ -1,5 +1,5 @@
-import 'package:delphis_app/bloc/discussion/discussion_bloc.dart';
 import 'package:delphis_app/bloc/discussion_list/discussion_list_bloc.dart';
+import 'package:delphis_app/data/repository/discussion.dart';
 import 'package:delphis_app/data/repository/user.dart';
 import 'package:delphis_app/design/sizes.dart';
 import 'package:delphis_app/design/text_theme.dart';
@@ -62,7 +62,7 @@ class ChatsList extends StatelessWidget {
         /* Select the current open list */
         return Consumer<HomePageTabNotifier>(
           builder: (context, currentTab, _) {
-            var showedDiscussions = [];
+            var showedDiscussions = <Discussion>[];
             switch (currentTab.value) {
               case HomePageTab.ARCHIVED:
                 showedDiscussions = state.archivedDiscussions;
@@ -144,7 +144,6 @@ class ChatsList extends StatelessWidget {
               onLoading: () {},
               child: ListView.builder(
                 padding: EdgeInsets.zero,
-                key: Key('discussion-list-view'),
                 scrollDirection: Axis.vertical,
                 shrinkWrap: true,
                 itemCount: showedDiscussions.length + 1,
@@ -152,43 +151,30 @@ class ChatsList extends StatelessWidget {
                   if (index == 0) return errorWidget;
                   index--;
                   var discussionElem = showedDiscussions[index];
-                  return BlocBuilder<DiscussionBloc, DiscussionState>(
-                    builder: (context, discussionState) {
-                      if (discussionState is DiscussionLoadedState &&
-                          discussionState.getDiscussion() != null) {
-                        if (discussionState.getDiscussion().id ==
-                            discussionElem.id) {
-                          showedDiscussions[index] =
-                              discussionState.getDiscussion();
-                          discussionElem = showedDiscussions[index];
-                        }
-                      }
-                      return SingleChat(
-                        discussion: discussionElem,
-                        canJoinDiscussions: currentUser?.isTwitterAuth ?? false,
-                        slidableController: this.slidableController,
-                        onJoinPressed: () {
-                          this.onJoinDiscussionPressed(discussionElem);
-                        },
-                        onPressed: () {
-                          this.onDiscussionPressed(discussionElem);
-                        },
-                        onDeletePressed: () {
-                          this.onDeleteDiscussionPressed(discussionElem);
-                        },
-                        onArchivePressed: () {
-                          this.onArchiveDiscussionPressed(discussionElem);
-                        },
-                        onActivatePressed: () {
-                          this.onActivateDiscussionPressed(discussionElem);
-                        },
-                        onMutePressed: () {
-                          this.onMuteDiscussionPressed(discussionElem);
-                        },
-                        onUnMutePressed: () {
-                          this.onUnMuteDiscussionPressed(discussionElem);
-                        },
-                      );
+                  return SingleChat(
+                    discussion: discussionElem,
+                    canJoinDiscussions: currentUser?.isTwitterAuth ?? false,
+                    slidableController: this.slidableController,
+                    onJoinPressed: () {
+                      this.onJoinDiscussionPressed(discussionElem);
+                    },
+                    onPressed: () {
+                      this.onDiscussionPressed(discussionElem);
+                    },
+                    onDeletePressed: () {
+                      this.onDeleteDiscussionPressed(discussionElem);
+                    },
+                    onArchivePressed: () {
+                      this.onArchiveDiscussionPressed(discussionElem);
+                    },
+                    onActivatePressed: () {
+                      this.onActivateDiscussionPressed(discussionElem);
+                    },
+                    onMutePressed: () {
+                      this.onMuteDiscussionPressed(discussionElem);
+                    },
+                    onUnMutePressed: () {
+                      this.onUnMuteDiscussionPressed(discussionElem);
                     },
                   );
                 },
@@ -235,7 +221,7 @@ class ChatsList extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             Text(
-              Intl.message("You haven't deleted any chat yet."),
+              Intl.message("You didn't delete any chat yet."),
               style: TextThemes.onboardHeading,
               textAlign: TextAlign.center,
             ),
@@ -244,7 +230,7 @@ class ChatsList extends StatelessWidget {
             ),
             Text(
               Intl.message(
-                  "You can delete a chat when you don't wish to participate in it anymore.\nDeleted chats will disappear from your feed after 90 days from the deletion."),
+                  "You can delete a chat if you don't wish to participate in it anymore.\nDeleted chats will disappear from your feed after 90 days from the deletion."),
               textAlign: TextAlign.center,
               style: TextThemes.onboardBody,
             ),

--- a/lib/screens/home_page/chats/chats_screen.dart
+++ b/lib/screens/home_page/chats/chats_screen.dart
@@ -1,11 +1,14 @@
 import 'package:delphis_app/bloc/discussion_list/discussion_list_bloc.dart';
 import 'package:delphis_app/data/repository/discussion.dart';
 import 'package:delphis_app/data/repository/user.dart';
+import 'package:delphis_app/notifiers/home_page_tab.dart';
 import 'package:delphis_app/screens/discussion/screen_args/discussion.dart';
 import 'package:delphis_app/screens/home_page/chats/chats_list.dart';
+import 'package:delphis_app/screens/home_page/home_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
+import 'package:provider/provider.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
 
 class ChatsScreen extends StatefulWidget {
@@ -59,30 +62,64 @@ class _ChatsScreenState extends State<ChatsScreen> with RouteAware {
 
   @override
   Widget build(BuildContext context) {
-    return ChatsList(
-      currentUser: this.widget.currentUser,
-      key: this._chatListKey,
-      refreshController: this._refreshController,
-      onJoinDiscussionPressed: (Discussion discussion) {
-        Navigator.of(context).pushNamed('/Discussion',
-            arguments: DiscussionArguments(
-              discussionID: discussion.id,
-              isStartJoinFlow: true,
-            ));
-      },
-      onDiscussionPressed: (Discussion discussion) {
-        Navigator.of(context).pushNamed('/Discussion',
-            arguments: DiscussionArguments(discussionID: discussion.id));
-      },
-      slidableController: slidableController,
-      onDeleteDiscussionPressed: (Discussion discussion) {
-        // TODO: Hook this up to backend mutations somehow
-      },
-      onArchiveDiscussionPressed: (Discussion discussion) {
-        // TODO: Hook this up to backend mutations somehow
-      },
-      onMuteDiscussionPressed: (Discussion discussion) {
-        // TODO: Hook this up to backend mutations somehow
+    return Consumer<HomePageTabNotifier>(
+      builder: (context, currentTab, _) {
+        return ChatsList(
+          currentUser: this.widget.currentUser,
+          key: this._chatListKey,
+          refreshController: this._refreshController,
+          onJoinDiscussionPressed: (Discussion discussion) {
+            Navigator.of(context).pushNamed('/Discussion',
+                arguments: DiscussionArguments(
+                  discussionID: discussion.id,
+                  isStartJoinFlow: true,
+                ));
+          },
+          onDiscussionPressed: (Discussion discussion) {
+            Navigator.of(context).pushNamed('/Discussion',
+                arguments: DiscussionArguments(discussionID: discussion.id));
+          },
+          slidableController: slidableController,
+          onDeleteDiscussionPressed: (Discussion discussion) {
+            if (currentTab.value == HomePageTab.ACTIVE) {
+              BlocProvider.of<DiscussionListBloc>(context).add(
+                DiscussionListDeleteEvent(discussion),
+              );
+            } else if (currentTab.value == HomePageTab.ARCHIVED) {
+              BlocProvider.of<DiscussionListBloc>(context).add(
+                DiscussionListDeleteEvent(discussion),
+              );
+            }
+          },
+          onArchiveDiscussionPressed: (Discussion discussion) {
+            if (currentTab.value == HomePageTab.ACTIVE) {
+              BlocProvider.of<DiscussionListBloc>(context).add(
+                DiscussionListArchiveEvent(discussion),
+              );
+            }
+          },
+          onActivateDiscussionPressed: (Discussion discussion) {
+            if (currentTab.value == HomePageTab.ARCHIVED) {
+              BlocProvider.of<DiscussionListBloc>(context).add(
+                DiscussionListActivateEvent(discussion),
+              );
+            }
+          },
+          onMuteDiscussionPressed: (Discussion discussion) {
+            if (currentTab.value == HomePageTab.ACTIVE) {
+              BlocProvider.of<DiscussionListBloc>(context).add(
+                DiscussionListMuteEvent(discussion),
+              );
+            }
+          },
+          onUnMuteDiscussionPressed: (Discussion discussion) {
+            if (currentTab.value == HomePageTab.ACTIVE) {
+              BlocProvider.of<DiscussionListBloc>(context).add(
+                DiscussionListUnMuteEvent(discussion),
+              );
+            }
+          },
+        );
       },
     );
   }

--- a/lib/screens/home_page/chats/chats_screen.dart
+++ b/lib/screens/home_page/chats/chats_screen.dart
@@ -106,9 +106,13 @@ class _ChatsScreenState extends State<ChatsScreen> with RouteAware {
             }
           },
           onMuteDiscussionPressed: (Discussion discussion) {
+            // TODO: Provide a way of choosing for how long muting a chat
             if (currentTab.value == HomePageTab.ACTIVE) {
               BlocProvider.of<DiscussionListBloc>(context).add(
-                DiscussionListMuteEvent(discussion),
+                DiscussionListMuteEvent(
+                  discussion,
+                  Duration(days: 365).inSeconds,
+                ),
               );
             }
           },

--- a/lib/screens/home_page/chats/single_chat.dart
+++ b/lib/screens/home_page/chats/single_chat.dart
@@ -1,9 +1,12 @@
 import 'package:delphis_app/data/repository/discussion.dart';
 import 'package:delphis_app/design/colors.dart';
+import 'package:delphis_app/notifiers/home_page_tab.dart';
 import 'package:delphis_app/screens/home_page/chats/single_chat_joined.dart';
 import 'package:delphis_app/screens/home_page/chats/single_chat_unjoined.dart';
+import 'package:delphis_app/screens/home_page/home_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
+import 'package:provider/provider.dart';
 
 class SingleChat extends StatelessWidget {
   final Discussion discussion;
@@ -13,6 +16,8 @@ class SingleChat extends StatelessWidget {
   final VoidCallback onPressed;
   final VoidCallback onArchivePressed;
   final VoidCallback onMutePressed;
+  final VoidCallback onUnMutePressed;
+  final VoidCallback onActivatePressed;
   final SlidableController slidableController;
 
   const SingleChat({
@@ -23,21 +28,21 @@ class SingleChat extends StatelessWidget {
     @required this.canJoinDiscussions,
     @required this.onArchivePressed,
     @required this.onMutePressed,
+    @required this.onUnMutePressed,
+    @required this.onActivatePressed,
     this.slidableController,
   }) : super();
 
   @override
   Widget build(BuildContext context) {
     Widget contents;
-    if (this.discussion.meParticipant != null &&
-        this.discussion.meParticipant.hasJoined) {
+    if (this.discussion.meParticipant?.hasJoined ?? false) {
       contents = SingleChatJoined(
-          discussion: this.discussion,
-          onPressed: this.onPressed,
-          notificationCount: 0);
-    } else if (this.discussion.meParticipant == null ||
-        !this.discussion.meParticipant.hasJoined) {
-      // I have not joined this chat.
+        discussion: this.discussion,
+        onPressed: this.onPressed,
+        notificationCount: 0,
+      );
+    } else {
       contents = SingleChatUnjoined(
         canJoinDiscussion: this.canJoinDiscussions,
         discussion: this.discussion,
@@ -47,41 +52,81 @@ class SingleChat extends StatelessWidget {
       );
     }
 
-    return Slidable(
-      actionPane: SlidableDrawerActionPane(),
-      actionExtentRatio: 0.15,
-      controller: this.slidableController,
-      closeOnScroll: true,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          border: Border(
-            bottom:
-                BorderSide(color: Color.fromRGBO(22, 23, 28, 1.0), width: 1.0),
+    return Consumer<HomePageTabNotifier>(
+      child: contents,
+      builder: (context, currentTab, child) {
+        bool isHidden = false;
+        List<Widget> actions = [];
+        switch (currentTab.value) {
+          case HomePageTab.ARCHIVED:
+            isHidden = this.discussion.isDeletedLocally ||
+                this.discussion.isActivatedLocally;
+            actions = [
+              IconSlideAction(
+                caption: 'Delete',
+                color: ChathamColors.deleteChatSlideButtonColor,
+                icon: Icons.delete,
+                onTap: this.onDeletePressed,
+              ),
+              IconSlideAction(
+                caption: 'Restore',
+                icon: Icons.restore,
+                color: ChathamColors.archiveChatSlideButtonColor,
+                onTap: this.onActivatePressed,
+              ),
+            ];
+            break;
+          case HomePageTab.ACTIVE:
+            isHidden = this.discussion.isDeletedLocally ||
+                this.discussion.isArchivedLocally;
+            actions = [
+              IconSlideAction(
+                caption: 'Delete',
+                color: ChathamColors.deleteChatSlideButtonColor,
+                icon: Icons.delete,
+                onTap: this.onDeletePressed,
+              ),
+              IconSlideAction(
+                caption: this.discussion.isMuted ? 'Unmute' : 'Mute',
+                color: ChathamColors.muteChatSlideButtonColor,
+                icon: this.discussion.isMuted
+                    ? Icons.volume_up
+                    : Icons.volume_off,
+                onTap: this.onMutePressed,
+              ),
+              IconSlideAction(
+                caption: 'Archive',
+                icon: Icons.archive,
+                color: ChathamColors.archiveChatSlideButtonColor,
+                onTap: this.onArchivePressed,
+              ),
+            ];
+            break;
+          case HomePageTab.TRASHED:
+            break;
+        }
+
+        return Container(
+          height: isHidden ? 0 : null,
+          child: Slidable(
+            actionPane: SlidableDrawerActionPane(),
+            actionExtentRatio: 0.15,
+            controller: this.slidableController,
+            closeOnScroll: true,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                border: Border(
+                  bottom: BorderSide(
+                      color: Color.fromRGBO(22, 23, 28, 1.0), width: 1.0),
+                ),
+              ),
+              child: child,
+            ),
+            actions: <Widget>[],
+            secondaryActions: actions,
           ),
-        ),
-        child: contents,
-      ),
-      actions: <Widget>[],
-      secondaryActions: <Widget>[
-        IconSlideAction(
-          caption: 'Delete',
-          color: ChathamColors.deleteChatSlideButtonColor,
-          icon: Icons.delete,
-          onTap: this.onDeletePressed,
-        ),
-        IconSlideAction(
-          caption: 'Mute',
-          color: ChathamColors.muteChatSlideButtonColor,
-          icon: Icons.volume_off,
-          onTap: this.onMutePressed,
-        ),
-        IconSlideAction(
-          caption: 'Archive',
-          icon: Icons.archive,
-          color: ChathamColors.archiveChatSlideButtonColor,
-          onTap: this.onArchivePressed,
-        ),
-      ],
+        );
+      },
     );
   }
 }

--- a/lib/screens/home_page/chats/single_chat.dart
+++ b/lib/screens/home_page/chats/single_chat.dart
@@ -92,7 +92,9 @@ class SingleChat extends StatelessWidget {
                 icon: this.discussion.isMuted
                     ? Icons.volume_up
                     : Icons.volume_off,
-                onTap: this.onMutePressed,
+                onTap: this.discussion.isMuted
+                    ? this.onUnMutePressed
+                    : this.onMutePressed,
               ),
               IconSlideAction(
                 caption: 'Archive',

--- a/lib/screens/home_page/chats/single_chat_joined.dart
+++ b/lib/screens/home_page/chats/single_chat_joined.dart
@@ -47,6 +47,17 @@ class SingleChatJoined extends StatelessWidget {
       );
     }
 
+    Widget mutedIcon = Icon(
+      Icons.volume_off,
+      size: 20,
+      color: Colors.white,
+    );
+    if (!this.discussion.isMuted) {
+      mutedIcon = SizedBox(
+        width: 20,
+      );
+    }
+
     return Material(
       color: Colors.transparent,
       child: InkWell(
@@ -85,6 +96,8 @@ class SingleChatJoined extends StatelessWidget {
                     this.discussion.moderator.userProfile.profileImageURL,
               ),
               SizedBox(width: SpacingValues.medium),
+              mutedIcon,
+              SizedBox(width: SpacingValues.small),
               SvgPicture.asset(
                 'assets/svg/forward_chevron.svg',
                 color: Color.fromRGBO(81, 82, 88, 1.0),

--- a/lib/screens/home_page/home_page_action_bar.dart
+++ b/lib/screens/home_page/home_page_action_bar.dart
@@ -1,5 +1,6 @@
 import 'package:delphis_app/design/sizes.dart';
 import 'package:delphis_app/screens/discussion/header_options_button.dart';
+import 'package:delphis_app/screens/home_page/home_page_action_bar_item.dart';
 import 'package:delphis_app/widgets/pressable/pressable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
@@ -31,88 +32,90 @@ class HomePageActionBar extends StatelessWidget {
       margin: EdgeInsets.symmetric(horizontal: SpacingValues.medium),
       color: this.backgroundColor,
       child: Container(
-        padding: EdgeInsets.symmetric(horizontal: SpacingValues.xxLarge),
+        padding: EdgeInsets.symmetric(
+          horizontal: SpacingValues.mediumLarge,
+        ),
         height: 64.0,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.start,
-              children: [
-                Pressable(
-                  onPressed: () {
-                    if (this.currentTab != HomePageTab.ACTIVE) {
-                      this.onTabPressed(HomePageTab.ACTIVE);
-                    }
-                  },
-                  width: 44.0,
-                  height: 44.0,
-                  showInkwell: false,
-                  child: Opacity(
-                    opacity: this.currentTab == HomePageTab.ACTIVE ? 1.0 : 0.4,
-                    child: SvgPicture.asset('assets/svg/chat-icon.svg'),
-                  ),
-                ),
-                SizedBox(width: SpacingValues.medium),
-                Pressable(
-                  onPressed: () {
-                    if (this.currentTab != HomePageTab.ARCHIVED) {
-                      this.onTabPressed(HomePageTab.ARCHIVED);
-                    }
-                  },
-                  width: 44.0,
-                  height: 44.0,
-                  showInkwell: false,
-                  child: Opacity(
-                    opacity:
-                        this.currentTab == HomePageTab.ARCHIVED ? 1.0 : 0.4,
-                    child: SvgPicture.asset('assets/svg/archive-icon.svg',
-                        height: 40.0, color: Colors.white),
-                  ),
-                ),
-                SizedBox(width: SpacingValues.medium),
-                Pressable(
-                  onPressed: () {
-                    if (this.currentTab != HomePageTab.TRASHED) {
-                      this.onTabPressed(HomePageTab.TRASHED);
-                    }
-                  },
-                  width: 34.0,
-                  height: 44.0,
-                  showInkwell: false,
-                  child: Opacity(
-                    opacity: this.currentTab == HomePageTab.TRASHED ? 1.0 : 0.4,
-                    child: SvgPicture.asset('assets/svg/trash.svg',
-                        height: 35.0, color: Colors.white),
-                  ),
-                ),
-              ],
-            ),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                SizedBox(
-                  width: 40.0,
-                  child: RaisedButton(
-                    padding: EdgeInsets.symmetric(horizontal: 5.0),
-                    shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(20.0)),
-                    color: Color.fromRGBO(247, 247, 255, 1.0),
-                    child: Icon(
-                      Icons.add,
-                      color: Colors.black,
-                      semanticLabel: "Add a discussion",
+            Expanded(
+              flex: 3,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  HomePageActionBarItem(
+                    icon: SvgPicture.asset(
+                      'assets/svg/chat-icon.svg',
+                      width: 26,
+                      height: 26,
                     ),
-                    onPressed: this.onNewChatPressed,
+                    title: "Active",
+                    onPressed: () {
+                      if (this.currentTab != HomePageTab.ACTIVE) {
+                        this.onTabPressed(HomePageTab.ACTIVE);
+                      }
+                    },
+                    active: this.currentTab == HomePageTab.ACTIVE,
                   ),
-                ),
-                SizedBox(width: SpacingValues.extraSmall),
-                HeaderOptionsButton(
-                  diameter: 44.0,
-                  isVertical: true,
-                  onPressed: this.onOptionSelected,
-                ),
-              ],
+                  HomePageActionBarItem(
+                    icon: Icon(
+                      Icons.archive,
+                      color: Colors.white,
+                      size: 28,
+                    ),
+                    title: "Archived",
+                    onPressed: () {
+                      if (this.currentTab != HomePageTab.ARCHIVED) {
+                        this.onTabPressed(HomePageTab.ARCHIVED);
+                      }
+                    },
+                    active: this.currentTab == HomePageTab.ARCHIVED,
+                  ),
+                  HomePageActionBarItem(
+                    icon: Icon(
+                      Icons.delete,
+                      color: Colors.white,
+                      size: 28,
+                    ),
+                    title: "Deleted",
+                    onPressed: () {
+                      if (this.currentTab != HomePageTab.TRASHED) {
+                        this.onTabPressed(HomePageTab.TRASHED);
+                      }
+                    },
+                    active: this.currentTab == HomePageTab.TRASHED,
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              flex: 1,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  Expanded(
+                    child: RaisedButton(
+                      padding: EdgeInsets.symmetric(horizontal: 5.0),
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(20.0)),
+                      color: Color.fromRGBO(247, 247, 255, 1.0),
+                      child: Icon(
+                        Icons.add,
+                        color: Colors.black,
+                        semanticLabel: "Add a discussion",
+                      ),
+                      onPressed: this.onNewChatPressed,
+                    ),
+                  ),
+                  HeaderOptionsButton(
+                    diameter: 38.0,
+                    isVertical: true,
+                    onPressed: this.onOptionSelected,
+                  ),
+                ],
+              ),
             ),
           ],
         ),

--- a/lib/screens/home_page/home_page_action_bar_item.dart
+++ b/lib/screens/home_page/home_page_action_bar_item.dart
@@ -1,0 +1,63 @@
+import 'package:delphis_app/design/sizes.dart';
+import 'package:delphis_app/design/text_theme.dart';
+import 'package:delphis_app/widgets/pressable/pressable.dart';
+import 'package:flutter/material.dart';
+
+class HomePageActionBarItem extends StatelessWidget {
+  final VoidCallback onPressed;
+  final bool active;
+  final Widget icon;
+  final String title;
+
+  const HomePageActionBarItem({
+    Key key,
+    @required this.onPressed,
+    @required this.active,
+    @required this.title,
+    @required this.icon,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: SpacingValues.xxSmall / 2,
+      ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return Pressable(
+            width: constraints.maxHeight,
+            height: constraints.maxWidth,
+            onPressed: this.onPressed,
+            showInkwell: false,
+            child: Opacity(
+              opacity: this.active ? 1.0 : 0.4,
+              child: Container(
+                color: Colors.transparent,
+                width: constraints.maxWidth,
+                height: constraints.maxHeight,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    this.icon,
+                    SizedBox(
+                      height: SpacingValues.xxSmall,
+                    ),
+                    Text(
+                      this.title,
+                      style: TextThemes.homeScreenActionBarItem,
+                      overflow: TextOverflow.fade,
+                      maxLines: 1,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
ADDRESSES CHAT-40, CHAT-41

This introduces the following:
- Home screen has been slightly restyled to include the 3 tabs (active chats, archived, deleted) and to be elastic with different screen layouts
- Business logic of the archive/delete/re-activate/mute/unmute features has been refactored to handle the 3-list model we use on the backend
- UI and BLoC have been hooked up, the next move is to make the frontend communicate with backend
- Archive, Mute, Unmute, Re-Activate, and Delete features have been implemented
- The chat list now includes anymations and more UX feedback given the fact that it can mutate a lot.
- Every operation is non-blocking, and gives immediate successful feedback to the user. if something goes wrong, a consistent state is asynchronously recovered.