### PR TITLE
Adding discussion viewer bloc to track last viewed post.

### DIFF
--- a/lib/bloc/discussion_viewer/discussion_viewer_bloc.dart
+++ b/lib/bloc/discussion_viewer/discussion_viewer_bloc.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+
+import 'package:bloc/bloc.dart';
+import 'package:delphis_app/data/repository/post.dart';
+import 'package:delphis_app/data/repository/viewer.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+
+part 'discussion_viewer_event.dart';
+part 'discussion_viewer_state.dart';
+
+class DiscussionViewerBloc
+    extends Bloc<DiscussionViewerEvent, DiscussionViewerState> {
+  final ViewerRepository viewerRepository;
+
+  DiscussionViewerBloc({
+    @required this.viewerRepository,
+  }) : super(DiscussionViewerUnInitialized());
+
+  @override
+  Stream<Transition<DiscussionViewerEvent, DiscussionViewerState>>
+      transformEvents(Stream<DiscussionViewerEvent> events, transitionFn) {
+    final defferedEvents = events
+        .where((e) => e is DiscussionViewerSetLastPostViewedEvent)
+        .debounceTime(const Duration(milliseconds: 5000))
+        .distinct()
+        .switchMap(transitionFn);
+    final forwardedEvents = events
+        .where((e) => e is! DiscussionViewerSetLastPostViewedEvent)
+        .asyncExpand(transitionFn);
+    return forwardedEvents.mergeWith([defferedEvents]);
+  }
+
+  @override
+  Stream<DiscussionViewerState> mapEventToState(
+    DiscussionViewerEvent event,
+  ) async* {
+    final currentState = this.state;
+    if (currentState is DiscussionViewerUnInitialized &&
+        event is DiscussionViewerLoadedEvent) {
+      yield DiscussionViewerInitialized(
+        viewer: event.viewer,
+        lastUpdateSent: null,
+        pendingUpdate: null,
+        isUpdating: false,
+      );
+    } else if (currentState is DiscussionViewerInitialized &&
+        event is DiscussionViewerSetLastPostViewedEvent) {
+      if (currentState.isUpdating) {
+        // We want to delay this for the future!
+        this.add(event);
+        return;
+      }
+      if (currentState.pendingUpdate != null &&
+          currentState.pendingUpdate
+              .createdAtAsDateTime()
+              .isBefore(event.post.createdAtAsDateTime())) {
+        return;
+      }
+      // A few other checks here:
+      if (event.post == null ||
+          (currentState.viewer.lastViewedPost != null &&
+              event.post.createdAtAsDateTime().isAfter(
+                  currentState.viewer.lastViewedPost.createdAtAsDateTime()))) {
+        // In either of these cases we want to not send any information!
+        return;
+      }
+
+      yield currentState.copyWith(
+        pendingUpdate: event.post,
+        isUpdating: true,
+      );
+      try {
+        final updatedViewer = await viewerRepository.setLastPostViewed(
+            currentState.viewer.id, event.post.id);
+        yield currentState.copyWith(
+          pendingUpdate: null,
+          lastUpdateSent: updatedViewer.lastViewed,
+          viewer: updatedViewer,
+          isUpdating: false,
+        );
+      } catch (err) {
+        yield currentState.copyWith(
+          pendingUpdate: currentState.pendingUpdate,
+          isUpdating: false,
+        );
+        this.add(event);
+      }
+    }
+  }
+}

--- a/lib/bloc/discussion_viewer/discussion_viewer_event.dart
+++ b/lib/bloc/discussion_viewer/discussion_viewer_event.dart
@@ -1,0 +1,30 @@
+part of 'discussion_viewer_bloc.dart';
+
+abstract class DiscussionViewerEvent extends Equatable {
+  const DiscussionViewerEvent();
+}
+
+class DiscussionViewerLoadedEvent extends DiscussionViewerEvent {
+  final Viewer viewer;
+
+  const DiscussionViewerLoadedEvent({
+    @required this.viewer,
+  });
+
+  @override
+  List<Object> get props =>
+      [this.viewer?.id, this.viewer?.discussion?.id, this.viewer?.lastViewed];
+}
+
+class DiscussionViewerSetLastPostViewedEvent extends DiscussionViewerEvent {
+  final Post post;
+
+  const DiscussionViewerSetLastPostViewedEvent({
+    @required this.post,
+  });
+
+  @override
+  List<Object> get props => [
+        this.post?.id,
+      ];
+}

--- a/lib/bloc/discussion_viewer/discussion_viewer_state.dart
+++ b/lib/bloc/discussion_viewer/discussion_viewer_state.dart
@@ -1,0 +1,48 @@
+part of 'discussion_viewer_bloc.dart';
+
+abstract class DiscussionViewerState extends Equatable {
+  const DiscussionViewerState();
+}
+
+class DiscussionViewerUnInitialized extends DiscussionViewerState {
+  @override
+  List<Object> get props => [];
+}
+
+class DiscussionViewerInitialized extends DiscussionViewerState {
+  final Viewer viewer;
+  final DateTime lastUpdateSent;
+  final Post pendingUpdate;
+  final bool isUpdating;
+
+  const DiscussionViewerInitialized({
+    @required this.viewer,
+    @required this.lastUpdateSent,
+    @required this.pendingUpdate,
+    @required this.isUpdating,
+  });
+
+  @override
+  List<Object> get props => [
+        this.viewer?.discussion?.id,
+        this.viewer?.id,
+        this.viewer?.lastViewed,
+        this.lastUpdateSent,
+        this.isUpdating,
+      ];
+
+  DiscussionViewerInitialized copyWith({
+    Viewer viewer,
+    DateTime lastUpdateSent,
+    // Required because may be null
+    @required Post pendingUpdate,
+    bool isUpdating,
+  }) {
+    return DiscussionViewerInitialized(
+      viewer: viewer ?? this.viewer,
+      lastUpdateSent: lastUpdateSent ?? this.lastUpdateSent,
+      pendingUpdate: pendingUpdate,
+      isUpdating: isUpdating ?? this.isUpdating,
+    );
+  }
+}

--- a/lib/chatham_app.dart
+++ b/lib/chatham_app.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 
 import 'package:delphis_app/bloc/app/app_bloc.dart';
 import 'package:delphis_app/bloc/discussion_list/discussion_list_bloc.dart';
+import 'package:delphis_app/bloc/discussion_viewer/discussion_viewer_bloc.dart';
 import 'package:delphis_app/bloc/gql_client/gql_client_bloc.dart';
 import 'package:delphis_app/bloc/mention/mention_bloc.dart';
 import 'package:delphis_app/bloc/superpowers/superpowers_bloc.dart';
@@ -10,6 +11,7 @@ import 'package:delphis_app/bloc/upsert_chat/upsert_discussion_bloc.dart';
 import 'package:delphis_app/data/repository/discussion.dart';
 import 'package:delphis_app/data/repository/media.dart';
 import 'package:delphis_app/data/repository/user.dart';
+import 'package:delphis_app/data/repository/viewer.dart';
 import 'package:delphis_app/notifiers/home_page_tab.dart';
 import 'package:delphis_app/screens/auth/base/sign_in.dart';
 import 'package:delphis_app/screens/discussion/naming_discussion.dart';
@@ -348,6 +350,14 @@ class ChathamAppState extends State<ChathamApp>
                                         BlocProvider.of<DiscussionBloc>(
                                             context)),
                               ),
+                              BlocProvider<DiscussionViewerBloc>(
+                                lazy: true,
+                                create: (context) => DiscussionViewerBloc(
+                                  viewerRepository:
+                                      RepositoryProvider.of<ViewerRepository>(
+                                          context),
+                                ),
+                              ),
                               BlocProvider<SuperpowersBloc>(
                                 create: (context) => SuperpowersBloc(
                                   discussionRepository: RepositoryProvider.of<
@@ -378,6 +388,26 @@ class ChathamAppState extends State<ChathamApp>
                                     BlocProvider.of<MentionBloc>(context).add(
                                         AddMentionDataEvent(
                                             discussion: state.getDiscussion()));
+                                    if (state.getDiscussion()?.meViewer !=
+                                        null) {
+                                      BlocProvider.of<DiscussionViewerBloc>(
+                                              context)
+                                          .add(
+                                        DiscussionViewerLoadedEvent(
+                                          viewer:
+                                              state.getDiscussion().meViewer,
+                                        ),
+                                      );
+                                      BlocProvider.of<DiscussionViewerBloc>(
+                                              context)
+                                          .add(
+                                        DiscussionViewerSetLastPostViewedEvent(
+                                            post: state
+                                                .getDiscussion()
+                                                ?.postsCache
+                                                ?.last),
+                                      );
+                                    }
                                   }
                                 }),
                                 BlocListener<AppBloc, AppState>(

--- a/lib/data/provider/mutations.dart
+++ b/lib/data/provider/mutations.dart
@@ -7,6 +7,7 @@ import 'package:delphis_app/data/repository/participant.dart';
 import 'package:delphis_app/data/repository/post_content_input.dart';
 import 'package:delphis_app/data/repository/twitter_user.dart';
 import 'package:delphis_app/data/repository/user_device.dart';
+import 'package:delphis_app/data/repository/viewer.dart';
 import 'package:delphis_app/design/colors.dart';
 import 'package:flutter/material.dart';
 
@@ -45,6 +46,33 @@ class AddPostGQLMutation extends GQLMutation<Post> {
 
   Post parseResult(dynamic data) {
     return Post.fromJson(data["addPost"]);
+  }
+}
+
+class SetLastPostViewedMutation extends GQLMutation<Viewer> {
+  final String viewerID;
+  final String postID;
+
+  final String _mutation = """
+    mutation setLastPostViewed(\$viewerID: ID!, \$postID: ID!) {
+      setLastPostViewed(viewerID: \$viewerID, postID: \$postID) {
+        ...ViewerInfoFragment
+      }
+    }
+    $ViewerInfoFragment
+  """;
+
+  const SetLastPostViewedMutation({
+    @required this.viewerID,
+    @required this.postID,
+  });
+
+  String mutation() {
+    return this._mutation;
+  }
+
+  Viewer parseResult(dynamic data) {
+    return Viewer.fromJson(data["setLastPostViewed"]);
   }
 }
 

--- a/lib/data/provider/queries.dart
+++ b/lib/data/provider/queries.dart
@@ -12,6 +12,20 @@ const InviterParticipantInfoFragment = """
   }
 """;
 
+const ViewerInfoFragment = """
+  fragment ViewerInfoFragment on Viewer {
+    id
+    discussion {
+      id
+    }
+    lastViewed
+    lastViewedPost {
+      id
+      createdAt
+    }
+  }
+""";
+
 const ParticipantInfoFragment = """
   fragment ParticipantInfoFragment on Participant {
     id
@@ -262,12 +276,16 @@ const DiscussionListFragment = """
     participants {
       ...ParticipantInfoFragment
     }
+    meViewer {
+      ...ViewerInfoFragment
+    }
     anonymityType
     iconURL
     discussionJoinability
   }
   $DiscussionModeratorFragment
   $ParticipantInfoFragment
+  $ViewerInfoFragment
 """;
 
 const DiscussionFragmentFull = """

--- a/lib/data/repository/discussion.dart
+++ b/lib/data/repository/discussion.dart
@@ -1,3 +1,4 @@
+import 'package:delphis_app/data/repository/viewer.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
@@ -513,6 +514,7 @@ class Discussion extends Equatable implements Entity {
   final List<HistoricalString> descriptionHistory;
   final DiscussionJoinabilitySetting discussionJoinability;
   final DateTime mutedUntil;
+  final Viewer meViewer;
 
   @JsonAnnotation.JsonKey(ignore: true)
   List<Post> postsCache;
@@ -547,6 +549,7 @@ class Discussion extends Equatable implements Entity {
         isDeletedLocally,
         isActivatedLocally,
         isArchivedLocally,
+        meViewer.id,
       ];
 
   Discussion({
@@ -571,6 +574,7 @@ class Discussion extends Equatable implements Entity {
     this.isDeletedLocally = false,
     this.isActivatedLocally = false,
     this.isArchivedLocally = false,
+    this.meViewer,
   }) : this.postsCache =
             postsCache ?? (postsConnection?.asPostList() ?? List());
 
@@ -662,6 +666,7 @@ class Discussion extends Equatable implements Entity {
     bool isActivatedLocally,
     bool isDeletedLocally,
     bool isArchivedLocally,
+    Viewer meViewer,
   }) {
     return Discussion(
       id: id ?? this.id,
@@ -688,6 +693,7 @@ class Discussion extends Equatable implements Entity {
       isActivatedLocally: isActivatedLocally ?? this.isActivatedLocally,
       isDeletedLocally: isDeletedLocally ?? this.isDeletedLocally,
       isArchivedLocally: isArchivedLocally ?? this.isArchivedLocally,
+      meViewer: meViewer ?? this.meViewer,
     );
   }
 }

--- a/lib/data/repository/discussion.g.dart
+++ b/lib/data/repository/discussion.g.dart
@@ -50,6 +50,12 @@ Discussion _$DiscussionFromJson(Map<String, dynamic> json) {
         ?.toList(),
     discussionJoinability: _$enumDecodeNullable(
         _$DiscussionJoinabilitySettingEnumMap, json['discussionJoinability']),
+    mutedUntil: json['mutedUntil'] == null
+        ? null
+        : DateTime.parse(json['mutedUntil'] as String),
+    meViewer: json['meViewer'] == null
+        ? null
+        : Viewer.fromJson(json['meViewer'] as Map<String, dynamic>),
   );
 }
 
@@ -72,6 +78,8 @@ Map<String, dynamic> _$DiscussionToJson(Discussion instance) =>
       'descriptionHistory': instance.descriptionHistory,
       'discussionJoinability':
           _$DiscussionJoinabilitySettingEnumMap[instance.discussionJoinability],
+      'mutedUntil': instance.mutedUntil?.toIso8601String(),
+      'meViewer': instance.meViewer,
     };
 
 T _$enumDecode<T>(

--- a/lib/data/repository/viewer.dart
+++ b/lib/data/repository/viewer.dart
@@ -1,21 +1,68 @@
+import 'package:delphis_app/bloc/gql_client/gql_client_bloc.dart';
+import 'package:delphis_app/data/provider/mutations.dart';
 import 'package:equatable/equatable.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:flutter/material.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:json_annotation/json_annotation.dart' as JsonAnnotation;
 
 import 'discussion.dart';
 import 'post.dart';
 
 part 'viewer.g.dart';
 
-@JsonSerializable()
+class ViewerRepository {
+  final GqlClientBloc clientBloc;
+
+  const ViewerRepository({
+    @required this.clientBloc,
+  });
+
+  Future<Viewer> setLastPostViewed(String viewerID, String postID,
+      {int attempt = 1}) async {
+    final client = this.clientBloc.getClient();
+    if (client == null && attempt <= MAX_ATTEMPTS) {
+      return Future.delayed(Duration(seconds: BACKOFF * attempt), () {
+        return setLastPostViewed(viewerID, postID, attempt: attempt + 1);
+      });
+    } else if (client == null) {
+      throw Exception(
+          "Failed to get discussion because backend connection is severed");
+    }
+
+    final mutation = SetLastPostViewedMutation(
+      viewerID: viewerID,
+      postID: postID,
+    );
+
+    final QueryResult result = await client.mutate(
+      MutationOptions(
+        documentNode: gql(mutation.mutation()),
+        variables: {
+          'viewerID': viewerID,
+          'postID': postID,
+        },
+        update: (Cache cache, QueryResult result) {
+          return cache;
+        },
+      ),
+    );
+
+    if (result.hasException) {
+      throw result.exception;
+    }
+
+    return mutation.parseResult(result.data);
+  }
+}
+
+@JsonAnnotation.JsonSerializable()
 class Viewer extends Equatable {
   final String id;
   final Discussion discussion;
   final DateTime lastViewed;
   final Post lastViewedPost;
 
-  List<Object> get props => [
-    id, discussion, lastViewed, lastViewedPost
-  ];
+  List<Object> get props => [id, discussion, lastViewed, lastViewedPost];
 
   const Viewer({
     this.id,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:delphis_app/data/repository/participant.dart';
 import 'package:delphis_app/data/repository/twitter_user.dart';
 import 'package:delphis_app/data/repository/user.dart';
 import 'package:delphis_app/data/repository/user_device.dart';
+import 'package:delphis_app/data/repository/viewer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -46,6 +47,9 @@ void main() {
             create: (context) => MediaRepository()),
         RepositoryProvider<ParticipantRepository>(
             create: (context) => ParticipantRepository(
+                clientBloc: BlocProvider.of<GqlClientBloc>(context))),
+        RepositoryProvider<ViewerRepository>(
+            create: (context) => ViewerRepository(
                 clientBloc: BlocProvider.of<GqlClientBloc>(context))),
         RepositoryProvider<UserRepository>(
             create: (context) => UserRepository(

--- a/lib/screens/upsert_discussion/screen_arguments.g.dart
+++ b/lib/screens/upsert_discussion/screen_arguments.g.dart
@@ -62,5 +62,6 @@ const _$UpsertDiscussionScreenPageEnumMap = {
   UpsertDiscussionScreenPage.TITLE_DESCRIPTION: 'TITLE_DESCRIPTION',
   UpsertDiscussionScreenPage.TWITTER_AUTH: 'TWITTER_AUTH',
   UpsertDiscussionScreenPage.INVITATION_MODE: 'INVITATION_MODE',
+  UpsertDiscussionScreenPage.CREATION_LOADING: 'CREATION_LOADING',
   UpsertDiscussionScreenPage.CONFIRMATION: 'CONFIRMATION',
 };

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -724,7 +724,7 @@ packages:
     source: hosted
     version: "3.0.0"
   rxdart:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: rxdart
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,6 +69,8 @@ dependencies:
 
   characters: ^1.0.0
 
+  rxdart: ^0.24.1
+
 dev_dependencies:
   # TODO: We need to update image_test_utils to depend on the later version of mockito
   # (^4.0.0) so we can use the newer version of mockito


### PR DESCRIPTION
This updates (using a debouncer) the lastPostViewed on the viewer object.

Note that it doesn't update on new posts via the gql subscription. This would require some heavy rewiring (which we should do in the future but not worth the cost right now.)