### PR TITLE
CHAT-98: Fix issue

### DIFF
--- a/lib/bloc/discussion_list/discussion_list_bloc.dart
+++ b/lib/bloc/discussion_list/discussion_list_bloc.dart
@@ -52,6 +52,13 @@ class DiscussionListBloc
           timestamp: DateTime.now(),
         );
       }
+    } else if (event is DiscussionListClearEvent) {
+      yield DiscussionListLoaded(
+        activeDiscussions: [],
+        archivedDiscussions: [],
+        deletedDiscussions: [],
+        timestamp: DateTime.now(),
+      );
     }
 
     /* From this point on, events related to mute/unmute/archive/restore/delete 

--- a/lib/bloc/discussion_list/discussion_list_event.dart
+++ b/lib/bloc/discussion_list/discussion_list_event.dart
@@ -15,6 +15,17 @@ class DiscussionListFetchEvent extends DiscussionListEvent {
   List<Object> get props => [this.now];
 }
 
+class DiscussionListClearEvent extends DiscussionListEvent {
+  final DateTime now;
+
+  DiscussionListClearEvent()
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props => [this.now];
+}
+
 class DiscussionListDeleteEvent extends DiscussionListEvent {
   final DateTime now;
   final Discussion discussion;

--- a/lib/chatham_app.dart
+++ b/lib/chatham_app.dart
@@ -213,6 +213,26 @@ class ChathamAppState extends State<ChathamApp>
                       null);
                 }
               }),
+              /* Clears the current discussion list when user logs out. This is
+                 wanted as we don't want discussion from an account to be
+                 visible is user changes account. */
+              BlocListener<AuthBloc, AuthState>(
+                  listener: (context, AuthState state) {
+                if (state is LoggedOutAuthState) {
+                  BlocProvider.of<DiscussionListBloc>(context)
+                      .add(DiscussionListClearEvent());
+                }
+              }),
+              /* Forces refresh of discussions list when user logs out and then
+                 logs in with another accout. */
+              BlocListener<GqlClientBloc, GqlClientState>(
+                  listenWhen: (prev, curr) {
+                return prev is GqlClientConnectingState &&
+                    curr is GqlClientConnectedState;
+              }, listener: (context, state) {
+                BlocProvider.of<DiscussionListBloc>(context)
+                    .add(DiscussionListFetchEvent());
+              }),
               BlocListener<MeBloc, MeState>(listener: (context, MeState state) {
                 if (state is LoadedMeState) {
                   this.sendDeviceToServer(


### PR DESCRIPTION
ADDRESSES CHAT-98

This fixes the issue for which the discussion list wasn't refreshed when an user logged-out and then logged-in subsequently.