### PR TITLE
Home page UI refactor for Apple users

### DIFF
--- a/lib/screens/auth/base/sign_in.dart
+++ b/lib/screens/auth/base/sign_in.dart
@@ -30,28 +30,31 @@ class SignInScreen extends StatelessWidget {
         child: Scaffold(
           resizeToAvoidBottomInset: true,
           backgroundColor: Colors.black,
-          body: Container(
-            decoration: BoxDecoration(
-              color: Colors.black,
-            ),
-            alignment: Alignment.bottomCenter,
-            padding: EdgeInsets.symmetric(horizontal: SpacingValues.xxxxLarge),
-            child: LayoutBuilder(
-                builder: (BuildContext context, BoxConstraints constraints) {
-              return SizedBox(
-                height: constraints.maxHeight * 0.7,
-                child: Flex(
-                  direction: Axis.vertical,
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    SvgPicture.asset('assets/svg/twitter_logo.svg',
-                        color: ChathamColors.signInTwitterBackground,
-                        semanticsLabel: 'Twitter Logo',
-                        width: 96,
-                        height: twitterWidgetHeight),
-                    Column(
-                      mainAxisAlignment: MainAxisAlignment.end,
+          body: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: <Widget>[
+              Expanded(
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.black,
+                  ),
+                  alignment: Alignment.center,
+                  padding:
+                      EdgeInsets.symmetric(horizontal: SpacingValues.xxxxLarge),
+                  child: SingleChildScrollView(
+                    physics: BouncingScrollPhysics(),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      mainAxisSize: MainAxisSize.max,
                       children: [
+                        SvgPicture.asset(
+                          'assets/svg/twitter_logo.svg',
+                          color: ChathamColors.signInTwitterBackground,
+                          semanticsLabel: 'Twitter Logo',
+                          width: 96,
+                          height: twitterWidgetHeight,
+                        ),
+                        SizedBox(height: SpacingValues.extraLarge),
                         Text(
                           Intl.message(
                               "The app works best with Twitter, but if you're an Apple user you can sign in with Apple to explore discussions."),
@@ -64,7 +67,7 @@ class SignInScreen extends StatelessWidget {
                                 "Sign in to get smart recs on who to chat with and what to chat about. Sorry for the limitations — we're a small team right now."),
                             style: TextThemes.onboardBody,
                             textAlign: TextAlign.center),
-                        SizedBox(height: SpacingValues.mediumLarge),
+                        SizedBox(height: SpacingValues.large),
                         Column(
                           children: [
                             AnimatedSizeContainer(
@@ -105,7 +108,7 @@ class SignInScreen extends StatelessWidget {
                                 BlocProvider.of<AuthBloc>(context)
                                     .add(TwitterSignInAuthEvent());
                               },
-                              width: constraints.maxWidth,
+                              width: double.infinity,
                               height: 56.0,
                             ),
                             SizedBox(height: SpacingValues.small),
@@ -117,31 +120,30 @@ class SignInScreen extends StatelessWidget {
                             ),
                           ],
                         ),
-                        SizedBox(height: SpacingValues.large),
-                        RichText(
-                          text: TextSpan(
-                            children: [
-                              TextSpan(
-                                text: Intl.message('Write us an angry note'),
-                                style: TextThemes.signInAngryNote,
-                                recognizer: TapGestureRecognizer()
-                                  ..onTap = () async {
-                                    if (await canLaunch(feedbackLink)) {
-                                      launch(feedbackLink);
-                                    } else {
-                                      throw 'Could not launch mailto URL.';
-                                    }
-                                  },
-                              ),
-                            ],
-                          ),
-                        )
                       ],
+                    ),
+                  ),
+                ),
+              ),
+              RichText(
+                text: TextSpan(
+                  children: [
+                    TextSpan(
+                      text: Intl.message('Write us an angry note'),
+                      style: TextThemes.signInAngryNote,
+                      recognizer: TapGestureRecognizer()
+                        ..onTap = () async {
+                          if (await canLaunch(feedbackLink)) {
+                            launch(feedbackLink);
+                          } else {
+                            throw 'Could not launch mailto URL.';
+                          }
+                        },
                     ),
                   ],
                 ),
-              );
-            }),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/screens/home_page/chats/chats_list.dart
+++ b/lib/screens/home_page/chats/chats_list.dart
@@ -4,6 +4,7 @@ import 'package:delphis_app/data/repository/user.dart';
 import 'package:delphis_app/design/sizes.dart';
 import 'package:delphis_app/design/text_theme.dart';
 import 'package:delphis_app/notifiers/home_page_tab.dart';
+import 'package:delphis_app/screens/discussion_join/button.dart';
 import 'package:delphis_app/screens/home_page/chats/single_chat.dart';
 import 'package:delphis_app/screens/home_page/home_page.dart';
 import 'package:delphis_app/widgets/animated_size_container/animated_size_container.dart';
@@ -83,7 +84,7 @@ class ChatsList extends StatelessWidget {
               return Center(
                 child: Container(
                   margin: EdgeInsets.all(SpacingValues.large),
-                  child: getEmptyLisWidget(currentTab.value),
+                  child: getEmptyLisWidget(context, currentTab.value),
                 ),
               );
             }
@@ -190,15 +191,36 @@ class ChatsList extends StatelessWidget {
     );
   }
 
-  Widget getEmptyLisWidget(HomePageTab value) {
+  Widget getEmptyLisWidget(BuildContext context, HomePageTab value) {
     switch (value) {
       case HomePageTab.ACTIVE:
-        return Text(
-          Intl.message(
-              "Looks like you haven’t been invited to any discussions."),
-          style: TextThemes.onboardHeading,
-          textAlign: TextAlign.center,
+        return Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Text(
+              Intl.message(
+                  "Looks like you haven’t been invited to any discussions."),
+              style: TextThemes.onboardHeading,
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(
+              height: SpacingValues.mediumLarge,
+            ),
+            JoinActionButton(
+              padding: EdgeInsets.all(SpacingValues.mediumLarge),
+              onPressed: () {
+                BlocProvider.of<DiscussionListBloc>(context)
+                    .add(DiscussionListFetchEvent());
+              },
+              child: Text(
+                Intl.message("Try to reload"),
+                style:
+                    TextThemes.goIncognitoButton.copyWith(color: Colors.black),
+              ),
+            )
+          ],
         );
+
       case HomePageTab.ARCHIVED:
         return Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/screens/home_page/chats/chats_list.dart
+++ b/lib/screens/home_page/chats/chats_list.dart
@@ -193,9 +193,9 @@ class ChatsList extends StatelessWidget {
   Widget getEmptyLisWidget(HomePageTab value) {
     switch (value) {
       case HomePageTab.ACTIVE:
-        // TODO: create ad-hoc widget for checking twitter auth and welcome user
         return Text(
-          Intl.message("You have no active chats."),
+          Intl.message(
+              "Looks like you haven’t been invited to any discussions."),
           style: TextThemes.onboardHeading,
           textAlign: TextAlign.center,
         );

--- a/lib/screens/home_page/chats/chats_screen.dart
+++ b/lib/screens/home_page/chats/chats_screen.dart
@@ -4,6 +4,7 @@ import 'package:delphis_app/data/repository/user.dart';
 import 'package:delphis_app/notifiers/home_page_tab.dart';
 import 'package:delphis_app/screens/discussion/screen_args/discussion.dart';
 import 'package:delphis_app/screens/home_page/chats/chats_list.dart';
+import 'package:delphis_app/screens/home_page/chats/home_page_twitter_login.dart';
 import 'package:delphis_app/screens/home_page/home_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -62,6 +63,10 @@ class _ChatsScreenState extends State<ChatsScreen> with RouteAware {
 
   @override
   Widget build(BuildContext context) {
+    if (this.widget.currentUser == null ||
+        !this.widget.currentUser.isTwitterAuth) {
+      return HomePageTwitterLogin();
+    }
     return Consumer<HomePageTabNotifier>(
       builder: (context, currentTab, _) {
         return ChatsList(

--- a/lib/screens/home_page/chats/chats_screen.dart
+++ b/lib/screens/home_page/chats/chats_screen.dart
@@ -63,8 +63,11 @@ class _ChatsScreenState extends State<ChatsScreen> with RouteAware {
 
   @override
   Widget build(BuildContext context) {
-    if (this.widget.currentUser == null ||
-        !this.widget.currentUser.isTwitterAuth) {
+    if (this.widget.currentUser == null) {
+      return Center(
+        child: CircularProgressIndicator(),
+      );
+    } else if (!this.widget.currentUser.isTwitterAuth) {
       return HomePageTwitterLogin();
     }
     return Consumer<HomePageTabNotifier>(

--- a/lib/screens/home_page/chats/home_page_twitter_login.dart
+++ b/lib/screens/home_page/chats/home_page_twitter_login.dart
@@ -1,0 +1,92 @@
+import 'package:delphis_app/bloc/auth/auth_bloc.dart';
+import 'package:delphis_app/design/sizes.dart';
+import 'package:delphis_app/design/text_theme.dart';
+import 'package:delphis_app/screens/auth/base/widgets/loginWithTwitterButton/twitter_button.dart';
+import 'package:delphis_app/widgets/animated_size_container/animated_size_container.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+
+class HomePageTwitterLogin extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      alignment: Alignment.center,
+      padding: EdgeInsets.symmetric(horizontal: SpacingValues.xxxxLarge),
+      child: SingleChildScrollView(
+        physics: BouncingScrollPhysics(),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              Intl.message(
+                  "Looks like you haven’t been invited to any discussions."),
+              style: TextThemes.onboardHeading,
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: SpacingValues.small),
+            Text(
+              Intl.message(
+                  "Tell us who you are so we can look up your pending invites on social media."),
+              style: TextThemes.onboardBody,
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: SpacingValues.mediumLarge),
+            AnimatedSizeContainer(
+              builder: (context) {
+                return BlocBuilder<AuthBloc, AuthState>(
+                  builder: (context, state) {
+                    if (state is LoadingAuthState) {
+                      return Container(
+                        margin: EdgeInsets.only(bottom: SpacingValues.large),
+                        child: Center(
+                          child: CircularProgressIndicator(),
+                        ),
+                      );
+                    } else if (state is ErrorAuthState) {
+                      return Container(
+                        margin: EdgeInsets.only(bottom: SpacingValues.large),
+                        child: Center(
+                          child: Text(
+                            state.error.toString(),
+                            textAlign: TextAlign.center,
+                            style: TextThemes.discussionPostText.copyWith(
+                              color: Colors.red,
+                            ),
+                          ),
+                        ),
+                      );
+                    }
+                    return Container();
+                  },
+                );
+              },
+            ),
+            LoginWithTwitterButton(
+              onPressed: () {
+                BlocProvider.of<AuthBloc>(context)
+                    .add(TwitterSignInAuthEvent());
+              },
+              width: double.infinity,
+              height: 56.0,
+            ),
+            SizedBox(height: SpacingValues.xxLarge),
+            Text(
+              Intl.message(
+                  "While discussion participants are anonymous to each other, you are invited by the moderator using your real identity."),
+              style: TextThemes.discussionPostText,
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: SpacingValues.smallMedium),
+            Text(
+              Intl.message(
+                  "We verify that it’s you when you join a chat, but during the discussion, even the moderator doesn’t know who you are - they just know that everyone participating was someone they invited."),
+              style: TextThemes.discussionPostText,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home_page/home_page.dart
+++ b/lib/screens/home_page/home_page.dart
@@ -79,36 +79,34 @@ class HomePageScreen extends StatelessWidget {
                   currentUser: currentUser,
                 ),
               ),
-              currentUser == null || !currentUser.isTwitterAuth
-                  ? Container(width: 0, height: 0)
-                  : Consumer<HomePageTabNotifier>(
-                      builder: (context, currentTab, child) {
-                        return HomePageActionBar(
-                          currentTab: currentTab.value,
-                          backgroundColor: ChathamColors.topBarBackgroundColor,
-                          onNewChatPressed: () {
-                            Navigator.pushNamed(context, '/Discussion/Upsert',
-                                arguments: UpsertDiscussionArguments());
-                          },
-                          onTabPressed: (HomePageTab tab) {
-                            Provider.of<HomePageTabNotifier>(
-                              context,
-                              listen: false,
-                            ).value = tab;
-                          },
-                          onOptionSelected: (HeaderOption option) {
-                            switch (option) {
-                              case HeaderOption.logout:
-                                BlocProvider.of<AuthBloc>(context)
-                                    .add(LogoutAuthEvent());
-                                break;
-                              default:
-                                break;
-                            }
-                          },
-                        );
-                      },
-                    ),
+              Consumer<HomePageTabNotifier>(
+                builder: (context, currentTab, child) {
+                  return HomePageActionBar(
+                    currentTab: currentTab.value,
+                    backgroundColor: ChathamColors.topBarBackgroundColor,
+                    onNewChatPressed: () {
+                      Navigator.pushNamed(context, '/Discussion/Upsert',
+                          arguments: UpsertDiscussionArguments());
+                    },
+                    onTabPressed: (HomePageTab tab) {
+                      Provider.of<HomePageTabNotifier>(
+                        context,
+                        listen: false,
+                      ).value = tab;
+                    },
+                    onOptionSelected: (HeaderOption option) {
+                      switch (option) {
+                        case HeaderOption.logout:
+                          BlocProvider.of<AuthBloc>(context)
+                              .add(LogoutAuthEvent());
+                          break;
+                        default:
+                          break;
+                      }
+                    },
+                  );
+                },
+              ),
             ],
           ),
         );

--- a/lib/screens/home_page/home_page_action_bar.dart
+++ b/lib/screens/home_page/home_page_action_bar.dart
@@ -1,8 +1,10 @@
+import 'package:delphis_app/bloc/me/me_bloc.dart';
+import 'package:delphis_app/data/repository/user.dart';
 import 'package:delphis_app/design/sizes.dart';
 import 'package:delphis_app/screens/discussion/header_options_button.dart';
 import 'package:delphis_app/screens/home_page/home_page_action_bar_item.dart';
-import 'package:delphis_app/widgets/pressable/pressable.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 
 import 'home_page.dart';
@@ -37,89 +39,109 @@ class HomePageActionBar extends StatelessWidget {
         ),
         height: 64.0,
         child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          mainAxisAlignment: MainAxisAlignment.end,
           children: [
             Expanded(
-              flex: 3,
               child: Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: [
-                  HomePageActionBarItem(
-                    icon: SvgPicture.asset(
-                      'assets/svg/chat-icon.svg',
-                      width: 26,
-                      height: 26,
-                    ),
-                    title: "Active",
-                    onPressed: () {
-                      if (this.currentTab != HomePageTab.ACTIVE) {
-                        this.onTabPressed(HomePageTab.ACTIVE);
-                      }
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  BlocBuilder<MeBloc, MeState>(
+                    builder: (context, state) {
+                      return Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: this.buildActionList(context, state),
+                      );
                     },
-                    active: this.currentTab == HomePageTab.ACTIVE,
                   ),
-                  HomePageActionBarItem(
-                    icon: Icon(
-                      Icons.archive,
-                      color: Colors.white,
-                      size: 28,
-                    ),
-                    title: "Archived",
-                    onPressed: () {
-                      if (this.currentTab != HomePageTab.ARCHIVED) {
-                        this.onTabPressed(HomePageTab.ARCHIVED);
-                      }
-                    },
-                    active: this.currentTab == HomePageTab.ARCHIVED,
-                  ),
-                  HomePageActionBarItem(
-                    icon: Icon(
-                      Icons.delete,
-                      color: Colors.white,
-                      size: 28,
-                    ),
-                    title: "Deleted",
-                    onPressed: () {
-                      if (this.currentTab != HomePageTab.TRASHED) {
-                        this.onTabPressed(HomePageTab.TRASHED);
-                      }
-                    },
-                    active: this.currentTab == HomePageTab.TRASHED,
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizedBox(
+                        width: SpacingValues.mediumLarge,
+                      ),
+                      RaisedButton(
+                        padding: EdgeInsets.symmetric(horizontal: 5.0),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(20.0)),
+                        color: Color.fromRGBO(247, 247, 255, 1.0),
+                        child: Icon(
+                          Icons.add,
+                          color: Colors.black,
+                          semanticLabel: "Add a discussion",
+                        ),
+                        onPressed: this.onNewChatPressed,
+                      ),
+                    ],
                   ),
                 ],
               ),
             ),
-            Expanded(
-              flex: 1,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  Expanded(
-                    child: RaisedButton(
-                      padding: EdgeInsets.symmetric(horizontal: 5.0),
-                      shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(20.0)),
-                      color: Color.fromRGBO(247, 247, 255, 1.0),
-                      child: Icon(
-                        Icons.add,
-                        color: Colors.black,
-                        semanticLabel: "Add a discussion",
-                      ),
-                      onPressed: this.onNewChatPressed,
-                    ),
-                  ),
-                  HeaderOptionsButton(
-                    diameter: 38.0,
-                    isVertical: true,
-                    onPressed: this.onOptionSelected,
-                  ),
-                ],
-              ),
+            HeaderOptionsButton(
+              diameter: 38.0,
+              isVertical: true,
+              onPressed: this.onOptionSelected,
             ),
           ],
         ),
       ),
     );
+  }
+
+  List<Widget> buildActionList(BuildContext context, MeState state) {
+    User currentUser = MeBloc.extractMe(state);
+    if (currentUser == null || !currentUser.isTwitterAuth) {
+      return [
+        SizedBox(
+          width: 38,
+        ),
+      ];
+    }
+    return [
+      HomePageActionBarItem(
+        icon: SvgPicture.asset(
+          'assets/svg/chat-icon.svg',
+          width: 26,
+          height: 26,
+        ),
+        title: "Active",
+        onPressed: () {
+          if (this.currentTab != HomePageTab.ACTIVE) {
+            this.onTabPressed(HomePageTab.ACTIVE);
+          }
+        },
+        active: this.currentTab == HomePageTab.ACTIVE,
+      ),
+      HomePageActionBarItem(
+        icon: Icon(
+          Icons.archive,
+          color: Colors.white,
+          size: 28,
+        ),
+        title: "Archived",
+        onPressed: () {
+          if (this.currentTab != HomePageTab.ARCHIVED) {
+            this.onTabPressed(HomePageTab.ARCHIVED);
+          }
+        },
+        active: this.currentTab == HomePageTab.ARCHIVED,
+      ),
+      HomePageActionBarItem(
+        icon: Icon(
+          Icons.delete,
+          color: Colors.white,
+          size: 28,
+        ),
+        title: "Deleted",
+        onPressed: () {
+          if (this.currentTab != HomePageTab.TRASHED) {
+            this.onTabPressed(HomePageTab.TRASHED);
+          }
+        },
+        active: this.currentTab == HomePageTab.TRASHED,
+      ),
+    ];
   }
 }


### PR DESCRIPTION
ADRESSES CHAT-78, CHAT-107 (UI part)
- Implements the HomeScreen UX for non-Twitter authed users (i.e. Apple users)
- Fixes overflow issues on login screen
- Overall UX improvement in Home Screen