### PR TITLE
Fix uncolored mentions

### DIFF
--- a/lib/widgets/input/delphis_input_mentions_popup.dart
+++ b/lib/widgets/input/delphis_input_mentions_popup.dart
@@ -332,7 +332,7 @@ class _DelphisInputMentionsPopupState extends State<DelphisInputMentionsPopup> {
     newText += text.substring(offset);
 
     this.textController.setStyleOperator(
-        "$hintWithSymbol",
+        "$hintWithSymbol".replaceAll("(", "\(").replaceAll(")", "\)"),
         (s) =>
             s.copyWith(color: Colors.lightBlue, fontWeight: FontWeight.bold));
     this.textController.text = newText;


### PR DESCRIPTION
Since mentionable participants have parentheses in their displayName, the regex used to color the mention on the input field was not triggered properly anymore. This fixes the issue.