### PR TITLE
Fix discussion state leak on logout

### DIFF
--- a/lib/bloc/discussion/discussion_bloc.dart
+++ b/lib/bloc/discussion/discussion_bloc.dart
@@ -80,7 +80,9 @@ class DiscussionBloc extends Bloc<DiscussionEvent, DiscussionState> {
   @override
   Stream<DiscussionState> mapEventToState(DiscussionEvent event) async* {
     var currentState = this.state;
-    if (event is DiscussionQueryEvent &&
+    if (event is DiscussionClearEvent) {
+      yield DiscussionUninitializedState();
+    } else if (event is DiscussionQueryEvent &&
         !(currentState is DiscussionLoadingState)) {
       try {
         yield DiscussionLoadingState();

--- a/lib/bloc/discussion/discussion_event.dart
+++ b/lib/bloc/discussion/discussion_event.dart
@@ -290,3 +290,14 @@ class RequestDiscussionAccessEvent extends DiscussionEvent {
   @override
   List<Object> get props => [this.discussionID, this.timestamp];
 }
+
+class DiscussionClearEvent extends DiscussionEvent {
+  final DateTime now;
+
+  DiscussionClearEvent()
+      : this.now = DateTime.now(),
+        super();
+
+  @override
+  List<Object> get props => [this.now];
+}

--- a/lib/chatham_app.dart
+++ b/lib/chatham_app.dart
@@ -222,6 +222,8 @@ class ChathamAppState extends State<ChathamApp>
                 if (state is LoggedOutAuthState) {
                   BlocProvider.of<DiscussionListBloc>(context)
                       .add(DiscussionListClearEvent());
+                  BlocProvider.of<DiscussionBloc>(context)
+                      .add(DiscussionClearEvent());
                 }
               }),
               /* Forces refresh of discussions list when user logs out and then


### PR DESCRIPTION
When an user opens a discussion and then performs a logout, the DiscussionBloc state remains as it was. If a user logs in with another account and happens to have access to the same discussion, such a discussion would not reload due to DiscussionBloc maintaining the previous loaded state. This leaks info about the previously logged in user.

This bug has been fixed in this PR by putting DiscussionBloc in an unitialized state when a user logs out.