### PR TITLE
Add popup for failed post options

### DIFF
--- a/lib/bloc/discussion/discussion_bloc.dart
+++ b/lib/bloc/discussion/discussion_bloc.dart
@@ -290,6 +290,18 @@ class DiscussionBloc extends Bloc<DiscussionEvent, DiscussionState> {
 
       /* Trigger another creation attempt */
       this.add(event.localPost.event);
+    } else if (event is DiscussionLocalPostDeleteEvent &&
+        currentState is DiscussionLoadedState &&
+        currentState.getDiscussion() != null) {
+      /* Remove post from local caches */
+      currentState.localPosts.remove(event.localPost);
+      currentState.getDiscussion().postsCache.remove(event.localPost.post);
+
+      /* Yield new state with error */
+      yield currentState.update(
+        discussion: currentState.discussion,
+        localPosts: currentState.localPosts,
+      );
     } else if (event is DiscussionPostReceivedEvent &&
         currentState is DiscussionLoadedState &&
         currentState.getDiscussion() != null) {

--- a/lib/bloc/discussion/discussion_event.dart
+++ b/lib/bloc/discussion/discussion_event.dart
@@ -125,6 +125,18 @@ class DiscussionLocalPostRetryEvent extends DiscussionEvent {
   }) : super();
 }
 
+class DiscussionLocalPostDeleteEvent extends DiscussionEvent {
+  final DateTime timestamp = DateTime.now();
+  final LocalPost localPost;
+
+  @override
+  List<Object> get props => [this.localPost, this.timestamp];
+
+  DiscussionLocalPostDeleteEvent({
+    @required this.localPost,
+  }) : super();
+}
+
 class DiscussionPostReceivedEvent extends DiscussionEvent {
   final Post post;
 

--- a/lib/screens/discussion/discussion.dart
+++ b/lib/screens/discussion/discussion.dart
@@ -237,10 +237,14 @@ class DelphisDiscussionState extends State<DelphisDiscussion> with RouteAware {
                       return;
                     }
                   }
+                  showSuperpowersPopup(
+                    context,
+                    SuperpowersArguments(
+                      discussion: dState.getDiscussion(),
+                      localPost: localPost,
+                    ),
+                  );
                 }
-                BlocProvider.of<DiscussionBloc>(context).add(
-                  DiscussionLocalPostRetryEvent(localPost: localPost),
-                );
               },
             ),
           );

--- a/lib/screens/superpowers/superpowers_arguments.dart
+++ b/lib/screens/superpowers/superpowers_arguments.dart
@@ -1,3 +1,4 @@
+import 'package:delphis_app/bloc/discussion/discussion_bloc.dart';
 import 'package:delphis_app/data/repository/discussion.dart';
 import 'package:delphis_app/data/repository/participant.dart';
 import 'package:delphis_app/data/repository/post.dart';
@@ -6,22 +7,26 @@ class SuperpowersArguments {
   final Post post;
   final Discussion discussion;
   final Participant participant;
+  final LocalPost localPost;
 
   SuperpowersArguments({
     this.post,
     this.discussion,
     this.participant,
+    this.localPost,
   });
 
   SuperpowersArguments copyWith({
     Post post,
     Discussion discussion,
     Participant participant,
+    LocalPost localPost,
   }) {
     return SuperpowersArguments(
       post: post ?? this.post,
       discussion: discussion ?? this.discussion,
       participant: participant ?? this.participant,
+      localPost: localPost ?? this.localPost,
     );
   }
 }

--- a/lib/screens/superpowers_popup/superpowers_popup.dart
+++ b/lib/screens/superpowers_popup/superpowers_popup.dart
@@ -379,6 +379,66 @@ class _SuperpowersPopupScreenState extends State<SuperpowersPopupScreen> {
       );
     }
 
+    /* Retry sending local post post feature */
+    if (this.widget.arguments.localPost != null &&
+        !this.widget.arguments.localPost.isProcessing) {
+      list.add(
+        SuperpowersOption(
+          child: Container(
+            width: double.infinity,
+            height: double.infinity,
+            decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(SpacingValues.medium),
+                color: Colors.black),
+            clipBehavior: Clip.antiAlias,
+            child: Icon(Icons.settings_backup_restore, size: 40),
+          ),
+          title: Intl.message("Retry"),
+          description: Intl.message(
+              "An error occurred while posting this message. Attempt to send it again."),
+          onTap: () {
+            Navigator.of(context).pop();
+            BlocProvider.of<DiscussionBloc>(context).add(
+              DiscussionLocalPostRetryEvent(
+                localPost: this.widget.arguments.localPost,
+              ),
+            );
+            return true;
+          },
+        ),
+      );
+    }
+
+    /* Delete local post post feature */
+    if (this.widget.arguments.localPost != null &&
+        !this.widget.arguments.localPost.isProcessing) {
+      list.add(
+        SuperpowersOption(
+          child: Container(
+            width: double.infinity,
+            height: double.infinity,
+            decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(SpacingValues.medium),
+                color: Colors.black),
+            clipBehavior: Clip.antiAlias,
+            child: Icon(Icons.delete_forever, size: 40),
+          ),
+          title: Intl.message("Delete Post"),
+          description: Intl.message(
+              "Remove the selected post from this discussion, so that no participant will be able to read it."),
+          onTap: () {
+            Navigator.of(context).pop();
+            BlocProvider.of<DiscussionBloc>(context).add(
+              DiscussionLocalPostDeleteEvent(
+                localPost: this.widget.arguments.localPost,
+              ),
+            );
+            return true;
+          },
+        ),
+      );
+    }
+
     /* A user could have no actions avaliable */
     if (list.length == 0) {
       list.add(Container(


### PR DESCRIPTION
When a post fails to be sent, a red exclamation mark appears right next to it. By clicking this error indicator, a popup is shown to the user allowing to both delete the message or try to send it again.